### PR TITLE
feat: Slice 3-XR-Handoff — cross-session handoff with auto-trigger (#50)

### DIFF
--- a/.agents/progress/integration-scenarios-results-2026-05-20.json
+++ b/.agents/progress/integration-scenarios-results-2026-05-20.json
@@ -1,202 +1,23 @@
 {
-  "runAt": "2026-05-20T06:52:47.320Z",
-  "total": 57,
-  "passed": 56,
-  "failed": 1,
+  "runAt": "2026-05-20T21:01:58.835Z",
+  "total": 35,
+  "passed": 29,
+  "failed": 6,
   "skipped": 3,
-  "judgeAvailable": true,
+  "judgeAvailable": false,
   "results": [
-    {
-      "id": "A1",
-      "group": "A",
-      "description": "Korean one-sentence greeting (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "stdoutLen=7"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The model's reply is a natural Korean greeting in one sentence with no leaked reasoning markers.",
-        "raw": "{\"pass\": true, \"reason\": \"The model's reply is a natural Korean greeting in one sentence with no leaked reasoning markers.\"}"
-      },
-      "wallMs": 14277,
-      "observedTail": "[exit=0]\n안녕하세요!\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2114005) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "A2",
-      "group": "A",
-      "description": "English technical answer (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "stdoutLen=461"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The output correctly explains that the ? operator propagates Result/Option errors, unwraps Ok/Some values, and returns Err/None early with proper type conversion.",
-        "raw": "{\"pass\": true, \"reason\": \"The output correctly explains that the ? operator propagates Result/Option errors, unwraps Ok/Some values, and returns Err/None early with proper type conversion.\"}"
-      },
-      "wallMs": 32332,
-      "observedTail": "[exit=0]\nThe `?` operator in Rust is used for error propagation. When applied to a `Result` or `Option` value, it unwraps the value if it is `Ok` or `Some`, allowing the program to continue. If the value is `Err` or `None`, the operator immediately returns that error or `None` from the current function to the caller. For `Result`, the `?` operator automatically performs a type conversion using the `From` trait to ensure the error matches the function's return type.\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2116182) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "A3",
-      "group": "A",
-      "description": "persistent memory recall (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "p1.exit=0",
-          "p2.exit=0",
-          "factsRows=2"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The model correctly identified '보리차' as the user's favorite drink in p2.",
-        "raw": "{\"pass\": true, \"reason\": \"The model correctly identified '보리차' as the user's favorite drink in p2.\"}"
-      },
-      "wallMs": 81186,
-      "observedTail": "[p1 exit=0]\n네, 기억하겠습니다. 루크 님의 가장 좋아하는 음료는 보리차입니다.\n\n--- p1 stderr ---\n\nnaia-agent: memory=lite db=/tmp/naia-intg-A-IwoCgH/home-PUBtr8/.naia-agent/memory/cli.sqlite embed=bge-m3\n(node:2120619) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n\n\n[p2 exit=0]\n보리차입니다.\n\n--- p2 stderr ---\n\nnaia-agent: memory=lite db=/tmp/naia-intg-A-IwoCgH/home-PUBtr8/.naia-agent/memory/cli.sqlite embed=bge-m3\n(node:2123405) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n\n\n[sqlite facts rows after p1: 2]"
-    },
-    {
-      "id": "A4",
-      "group": "A",
-      "description": "no-tools refuse-fabricate (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0"
-        ]
-      },
-      "judge": {
-        "pass": false,
-        "reason": "judge transport error: The operation was aborted due to timeout"
-      },
-      "wallMs": 71334,
-      "observedTail": "[exit=0]\nI cannot.\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2125628) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "B1",
-      "group": "B",
-      "description": "read+explain (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The output correctly states that the function returns the sum of two provided arguments.",
-        "raw": "{\"pass\": true, \"reason\": \"The output correctly states that the function returns the sum of two provided arguments.\"}"
-      },
-      "wallMs": 45515,
-      "observedTail": "[exit=0]\nThis function returns the sum of two provided arguments.\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2127101) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "B2",
-      "group": "B",
-      "description": "bug spot (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "Output correctly identifies that returning 0 for division by zero is wrong and should raise an exception instead.",
-        "raw": "{\"pass\": true, \"reason\": \"Output correctly identifies that returning 0 for division by zero is wrong and should raise an exception instead.\"}"
-      },
-      "wallMs": 19806,
-      "observedTail": "[exit=0]\nThe function returns 0 when dividing by zero instead of raising an error. This is mathematically incorrect and masks bugs by silently returning a misleading value.\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2127647) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "B3",
-      "group": "B",
-      "description": "refactor proposal (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The function validates input type, non-negativity, and finiteness before multiplying.",
-        "raw": "{\"pass\": true, \"reason\": \"The function validates input type, non-negativity, and finiteness before multiplying.\"}"
-      },
-      "wallMs": 56734,
-      "observedTail": "[exit=0]\n```javascript\nfunction age(years) {\n  if (typeof years !== 'number' || isNaN(years) || years < 0) {\n    throw new TypeError('Invalid input: years must be a non-negative number.');\n  }\n  return years * 365;\n}\n```\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2130352) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "C1",
-      "group": "C",
-      "description": "native-tools error",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=2"
-        ]
-      },
-      "wallMs": 757,
-      "observedTail": "[exit=2]\nstdout:\nstderr:naia-agent: provider=openai-compat model=gemma3n:e4b\n(node:2134307) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n\nnaia-agent: turn failed — registry.ollama.ai/library/gemma3n:e4b does not support tools\n  This model has no native tool-calling. Exit (`exit`/Ctrl-D) and re-run with --no-tools:\n    pnpm naia-agent --no-tools                          # REPL\n    pnpm naia-agent --no-tools --memory \"your prompt\"   # one-shot, with memory\n"
-    },
-    {
-      "id": "F1",
-      "group": "F",
-      "description": "persona tone (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "Response includes pirate greeting 'Ahoy there, matey!' with pirate-style language.",
-        "raw": "{\"pass\": true, \"reason\": \"Response includes pirate greeting 'Ahoy there, matey!' with pirate-style language.\"}"
-      },
-      "wallMs": 14764,
-      "observedTail": "[exit=0]\nAhoy there, matey!\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2134355) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "F2",
-      "group": "F",
-      "description": "persona + memory (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "p1=0",
-          "p2=0"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The assistant correctly named the dog '코코' in p2 while maintaining a Korean tone.",
-        "raw": "{\"pass\": true, \"reason\": \"The assistant correctly named the dog '코코' in p2 while maintaining a Korean tone.\"}"
-      },
-      "wallMs": 58063,
-      "observedTail": "[p1 exit=0]\n네, 기억해 둘게요. 코코군요.\n\n\n[p2 exit=0]\n코코예요.\n\n--- p2 stderr ---\n\nnaia-agent: memory=lite db=/tmp/naia-intg-F-2V854b/home-eToRO5/.naia-agent/memory/cli.sqlite embed=bge-m3\n(node:2140877) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
     {
       "id": "H1",
       "group": "H",
       "description": "server-down clean hint",
       "mechanism": {
-        "pass": true,
+        "pass": false,
         "notes": [
-          "exit=2"
+          "exit=3"
         ]
       },
-      "wallMs": 637,
-      "observedTail": "naia-agent: provider=openai-compat model=absent\n\nnaia-agent: turn failed — Cannot connect to API: bad port\n  The model server at http://127.0.0.1:1/v1 is unreachable. Start it, or reconfigure:\n    pnpm naia-agent login --adk <naia-adk> \\\n      --main \"openai-compat|http://127.0.0.1:11434/v1|gemma3n:e4b\"\n"
+      "wallMs": 606,
+      "observedTail": "(node:3263967) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: ERROR — no LLM provider configured.\n  Quickest path: pnpm naia-agent login --adk <naia-adk-path> --main \"provider|baseUrl|model\"\n  Or set an env var: ANTHROPIC_API_KEY, GLM_API_KEY, or OPENAI_API_KEY+OPENAI_BASE_URL.\n  See: docs/llm-config-standard.md, docs/user-guide.md\n"
     },
     {
       "id": "H2",
@@ -208,8 +29,8 @@
           "exit=3"
         ]
       },
-      "wallMs": 298,
-      "observedTail": "(node:2143865) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: invalid manifest \"/tmp/naia-intg-H-BRxEPT/home-1w64Wd/bad.service.json\"\n{\"name\":\"error.manifest\",\"timestamp\":1779259710833,\"errorCode\":\"MANIFEST_INVALID\",\"severity\":\"error\",\"retryable\":false,\"data\":{\"detail\":\"invalid JSON: Expected property name or '}' in JSON at position 2 (line 1 column 3)\"},\"debug\":\"invalid JSON: Expected property name or '}' in JSON at position 2 (line 1 column 3)\"}\n"
+      "wallMs": 300,
+      "observedTail": "(node:3264016) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: invalid manifest \"/tmp/naia-intg-H-QeA3Q2/home-dU0rYa/bad.service.json\"\n{\"name\":\"error.manifest\",\"timestamp\":1779310910100,\"errorCode\":\"MANIFEST_INVALID\",\"severity\":\"error\",\"retryable\":false,\"data\":{\"detail\":\"invalid JSON: Expected property name or '}' in JSON at position 2 (line 1 column 3)\"},\"debug\":\"invalid JSON: Expected property name or '}' in JSON at position 2 (line 1 column 3)\"}\n"
     },
     {
       "id": "H3",
@@ -222,7 +43,7 @@
         ]
       },
       "wallMs": 308,
-      "observedTail": "naia-agent: ERROR — no LLM provider configured.\n  Quickest path: pnpm naia-agent login --adk <naia-adk-path> --main \"provider|baseUrl|model\"\n  Or set an env var: ANTHROPIC_API_KEY, GLM_API_KEY, or OPENAI_API_KEY+OPENAI_BASE_URL.\n  See: docs/llm-config-standard.md, docs/user-guide.md\n"
+      "observedTail": "(node:3264058) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: ERROR — no LLM provider configured.\n  Quickest path: pnpm naia-agent login --adk <naia-adk-path> --main \"provider|baseUrl|model\"\n  Or set an env var: ANTHROPIC_API_KEY, GLM_API_KEY, or OPENAI_API_KEY+OPENAI_BASE_URL.\n  See: docs/llm-config-standard.md, docs/user-guide.md\n"
     },
     {
       "id": "I1",
@@ -234,67 +55,34 @@
           "exit=3"
         ]
       },
-      "wallMs": 325,
-      "observedTail": "naia-agent login: --main: apiKeyRef looks like a RAW SECRET — pass a name (env var / keychain entry), not the key itself\nusage: pnpm naia-agent login --adk <path>\n         [--main \"provider|baseUrl|model[|apiKeyRef]\"]\n         [--sub  \"provider|baseUrl|model[|apiKeyRef]\"]\n         [--embedded \"provider|baseUrl|model|dims[|apiKeyRef]\"]\n         [--key REF=VALUE]   (stored in OS keychain, never plaintext)\n"
+      "wallMs": 288,
+      "observedTail": "naia-agent login: missing --key <provider>\n  providers: naia | anthropic | openai | glm | vllm | ollama | vertex\n  example:   pnpm naia-agent login --key anthropic\n"
     },
     {
       "id": "I2",
       "group": "I",
       "description": "show no value leak",
       "mechanism": {
-        "pass": true,
+        "pass": false,
         "notes": [
           "exit=0"
         ]
       },
-      "wallMs": 627,
-      "observedTail": "ration (no secret values)\n  naia-adk:    /tmp/naia-intg-I-0WsZOc/adk-jm0Tq1\n  llm.json:    /tmp/naia-intg-I-0WsZOc/adk-jm0Tq1/naia-settings/llm.json\n  main       openai-compat gemma4:31b @ http://127.0.0.1:11434/v1  apiKeyRef=MY_FAKE_TOKEN_NAME\n  sub        <none>\n  embedded   <none>\n  resolved:    openai-compat gemma4:31b @ http://127.0.0.1:11434/v1\n  memory db:   /tmp/naia-intg-I-0WsZOc/home-3pU9hH/.naia-agent/memory/cli.sqlite  (absent)\n  config.json: /tmp/naia-intg-I-0WsZOc/home-3pU9hH/.naia-agent/config.json\n  (apiKeyRef shows the env var / keychain NAME only — values are never printed.)\n"
-    },
-    {
-      "id": "F3",
-      "group": "F",
-      "description": "persona-only --no-default-system (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "Output is exactly one short sentence introducing UNIT-7.",
-        "raw": "{\"pass\": true, \"reason\": \"Output is exactly one short sentence introducing UNIT-7.\"}"
-      },
-      "wallMs": 25696,
-      "observedTail": "[exit=0]\nI am UNIT-7.\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2144051) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
-      "id": "F4",
-      "group": "F",
-      "description": "4KB persona pass-through (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "personaLen=3383",
-          "stdoutLen=55"
-        ]
-      },
-      "wallMs": 3841,
-      "observedTail": "[exit=0, personaLen=3383]\nGreetings; I am Solas, the lorekeeper of this library.\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2146254) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
+      "wallMs": 594,
+      "observedTail": "naia-agent show — current configuration (no secret values)\n  naia-adk:    <unset>\n  llm.json:    <n/a>\n  main       <none>\n  sub        <none>\n  embedded   <none>\n  resolved:    <none — set ANTHROPIC_API_KEY / OPENAI_API_KEY+OPENAI_BASE_URL / GLM_API_KEY, or `naia-agent login`>\n  memory db:   /tmp/naia-intg-I-Gshjtj/home-NMoyGg/.naia-agent/memory/cli.sqlite  (absent)\n  config.json: /tmp/naia-intg-I-Gshjtj/home-NMoyGg/.naia-agent/config.json\n  (apiKeyRef shows the env var / keychain NAME only — values are never printed.)\n"
     },
     {
       "id": "H4",
       "group": "H",
       "description": "--memory no embedded role",
       "mechanism": {
-        "pass": true,
+        "pass": false,
         "notes": [
-          "exit=0"
+          "exit=3"
         ]
       },
-      "wallMs": 4899,
-      "observedTail": "naia-agent: provider=openai-compat model=gemma4:31b\nnaia-agent: --memory needs a valid 'embedded' role (run `naia-agent login --embedded \"provider|baseUrl|model|dims\"` or fix naia-settings/llm.json) — falling back to ephemeral memory.\n(node:2146630) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
+      "wallMs": 613,
+      "observedTail": "(node:3264382) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: ERROR — no LLM provider configured.\n  Quickest path: pnpm naia-agent login --adk <naia-adk-path> --main \"provider|baseUrl|model\"\n  Or set an env var: ANTHROPIC_API_KEY, GLM_API_KEY, or OPENAI_API_KEY+OPENAI_BASE_URL.\n  See: docs/llm-config-standard.md, docs/user-guide.md\n"
     },
     {
       "id": "H5",
@@ -306,8 +94,8 @@
           "exit=3"
         ]
       },
-      "wallMs": 312,
-      "observedTail": "naia-agent: unknown arg: --this-flag-does-not-exist\nusage: pnpm naia-agent [prompt] [--mode=direct|supervisor] [--workdir DIR] [--debug]\n       pnpm naia-agent [prompt] [--no-tools] [--no-default-system] [--memory] [--system \"…\"]\n       pnpm naia-agent login --adk <path> [--main …] [--sub …] [--embedded …] [--key REF=VAL]\n       pnpm naia-agent show                       # show current config (no secret values)\n       pnpm naia-agent [prompt] --service app.service.json\n       pnpm naia-agent [prompt] --mode=supervisor [--no-verify] [-m model] [--adapter shell -- cmd args]\n"
+      "wallMs": 325,
+      "observedTail": "pt] [--no-tools] [--no-default-system] [--memory] [--system \"…\"]\n       pnpm naia-agent [prompt] [--compact-strategy reactive|realtime|anthropic-native|off]\n       pnpm naia-agent login --adk <path> [--main …] [--sub …] [--embedded …] [--key REF=VAL]\n       pnpm naia-agent show                       # show current config (no secret values)\n       pnpm naia-agent --stdio\n       pnpm naia-agent [prompt] --service app.service.json\n       pnpm naia-agent [prompt] --mode=supervisor [--no-verify] [-m model] [--adapter shell -- cmd args]\n       pnpm naia-agent login --key anthropic|openai|glm|vertex\n"
     },
     {
       "id": "I3",
@@ -319,8 +107,8 @@
           "exit=3"
         ]
       },
-      "wallMs": 309,
-      "observedTail": "naia-agent login: --main: apiKeyRef looks like a RAW SECRET — pass a name (env var / keychain entry), not the key itself\nusage: pnpm naia-agent login --adk <path>\n         [--main \"provider|baseUrl|model[|apiKeyRef]\"]\n         [--sub  \"provider|baseUrl|model[|apiKeyRef]\"]\n         [--embedded \"provider|baseUrl|model|dims[|apiKeyRef]\"]\n         [--key REF=VALUE]   (stored in OS keychain, never plaintext)\n"
+      "wallMs": 306,
+      "observedTail": "naia-agent login: missing --key <provider>\n  providers: naia | anthropic | openai | glm | vllm | ollama | vertex\n  example:   pnpm naia-agent login --key anthropic\n"
     },
     {
       "id": "I4",
@@ -332,21 +120,21 @@
           "exit=3"
         ]
       },
-      "wallMs": 296,
-      "observedTail": "naia-agent login: --main: apiKeyRef looks like a RAW SECRET — pass a name (env var / keychain entry), not the key itself\nusage: pnpm naia-agent login --adk <path>\n         [--main \"provider|baseUrl|model[|apiKeyRef]\"]\n         [--sub  \"provider|baseUrl|model[|apiKeyRef]\"]\n         [--embedded \"provider|baseUrl|model|dims[|apiKeyRef]\"]\n         [--key REF=VALUE]   (stored in OS keychain, never plaintext)\n"
+      "wallMs": 292,
+      "observedTail": "naia-agent login: missing --key <provider>\n  providers: naia | anthropic | openai | glm | vllm | ollama | vertex\n  example:   pnpm naia-agent login --key anthropic\n"
     },
     {
       "id": "I5",
       "group": "I",
       "description": "positive control — legit ref name accepted",
       "mechanism": {
-        "pass": true,
+        "pass": false,
         "notes": [
-          "exit=0"
+          "exit=3"
         ]
       },
-      "wallMs": 295,
-      "observedTail": "naia-agent login: configured.\n  naia-adk:   /tmp/naia-intg-I2-NUqmS7/adk-ThYVUS\n  llm.json:   /tmp/naia-intg-I2-NUqmS7/adk-ThYVUS/naia-settings/llm.json\n  main: openai-compat gemma4:31b (key→MY_API_KEY)\nRun: pnpm naia-agent --no-tools \"your prompt\"\n"
+      "wallMs": 296,
+      "observedTail": "naia-agent login: missing --key <provider>\n  providers: naia | anthropic | openai | glm | vllm | ollama | vertex\n  example:   pnpm naia-agent login --key anthropic\n"
     },
     {
       "id": "E1",
@@ -358,8 +146,8 @@
           "exit=3"
         ]
       },
-      "wallMs": 294,
-      "observedTail": "(node:2147446) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: manifest llm.backend \"langgraph\" not implemented yet (deferred to Slice 3-XR-K). Reserve stub: schema accepts the value but no live dispatcher is wired.\n"
+      "wallMs": 299,
+      "observedTail": "(node:3264621) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: manifest llm.backend \"langgraph\" not implemented yet (deferred to Slice 3-XR-K). Reserve stub: schema accepts the value but no live dispatcher is wired.\n"
     },
     {
       "id": "E2",
@@ -371,8 +159,8 @@
           "exit=3"
         ]
       },
-      "wallMs": 290,
-      "observedTail": "(node:2147469) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: manifest llm.backend \"rag-retriever\" not implemented yet (deferred to Slice 3-XR-K). Reserve stub: schema accepts the value but no live dispatcher is wired.\n"
+      "wallMs": 295,
+      "observedTail": "(node:3264667) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: manifest llm.backend \"rag-retriever\" not implemented yet (deferred to Slice 3-XR-K). Reserve stub: schema accepts the value but no live dispatcher is wired.\n"
     },
     {
       "id": "J2a",
@@ -386,50 +174,6 @@
       "skipped": "structurally identical to F2; tracked here for grid completeness"
     },
     {
-      "id": "D1",
-      "group": "D",
-      "description": "naia-adk skills/ load (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "hits=6/6",
-          "names=time,weather,memo,sessions,system-status,diagnostics"
-        ]
-      },
-      "wallMs": 31684,
-      "observedTail": "[exit=0]\nstdout:\nbash\nread_file\nwrite_file\nedit_file\nlist_files\nchannel-management\nconfig\ncron\ndiagnostics\ndoc-coauthoring\ndocument-generation\nemail\nmemo\nnotify\nread-doc\nreview-pass\nservice-management\nsessions\nskill-manager\nsms\nsystem-status\ntime\nweather\nweb-monitoring\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2147515) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: skills-dir warn: failed to read SKILL.md\n"
-    },
-    {
-      "id": "D2",
-      "group": "D",
-      "description": "composite executor smoke (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "bashFired=true",
-          "quoted=true"
-        ]
-      },
-      "wallMs": 13787,
-      "observedTail": "[exit=0]\nDELTA-COMPOSITE-2026\n\n--- stderr ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2152265) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: skills-dir warn: failed to read SKILL.md\n[tool] bash({\"command\":\"echo DELTA-COMPOSITE-2026\"})\n"
-    },
-    {
-      "id": "D3",
-      "group": "D",
-      "description": "missing --skills-dir graceful",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "stdoutLen=6"
-        ]
-      },
-      "wallMs": 10138,
-      "observedTail": "naia-agent: provider=openai-compat model=gemma4:31b\n(node:2153959) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
-    },
-    {
       "id": "D4",
       "group": "D",
       "description": "skill invoke parse-only contract",
@@ -441,7 +185,7 @@
           "invokeMsgLen=59"
         ]
       },
-      "wallMs": 141,
+      "wallMs": 120,
       "observedTail": "list[0..5]=channel-management,config,cron,diagnostics,doc-coauthoring\ninvoke('time'): FileSkillLoader is parse-only — no invoker wired for \"time\""
     },
     {
@@ -456,7 +200,7 @@
           "tier-distribution: T0=3 T1=12 T2=2 T3=2"
         ]
       },
-      "wallMs": 1,
+      "wallMs": 2,
       "observedTail": "all 19 valid"
     },
     {
@@ -471,7 +215,7 @@
           "missing=—"
         ]
       },
-      "wallMs": 4,
+      "wallMs": 2,
       "observedTail": "got: channel-management,config,cron,diagnostics,doc-coauthoring,document-generation,email,memo,notify,read-doc,review-pass,service-management,sessions,skill-manager,sms,system-status,time,weather,web-monitoring"
     },
     {
@@ -487,7 +231,7 @@
           "tier-distribution: T0=0 T1=10"
         ]
       },
-      "wallMs": 2,
+      "wallMs": 1,
       "observedTail": "names: channel-management,doc-coauthoring,document-generation,email,read-doc,review-pass,service-management,sms,web-monitoring,wp-archive"
     },
     {
@@ -540,15 +284,15 @@
       "group": "M",
       "description": "REPL safeTurn cross-turn survival",
       "mechanism": {
-        "pass": true,
+        "pass": false,
         "notes": [
-          "exit=0",
-          "promptCount=3",
-          "stderrHas turn failed=true"
+          "exit=3",
+          "promptCount=0",
+          "stderrHas turn failed=false"
         ]
       },
-      "wallMs": 664,
-      "observedTail": "stderr tail: naia-agent: provider=openai-compat model=absent\n(node:2155650) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n\nnaia-agent: turn failed — Cannot connect to API: bad port\n  The model server at http://127.0.0.1:1/v1 is unreachable. Start it, or reconfigure:\n    pnpm naia-agent login --adk <naia-adk> \\\n      --main \"openai-compat|http://127.0.0.1:11434/v1|gemma3n:e4b\"\n\nnaia-agent: turn failed — Cannot connect to API: bad port\n  The model server at http://127.0.0.1:1/v1 is unreachable. Start it, or reconfigure:\n    pnpm naia-agent login --adk <naia-adk> \\\n      --main \"openai-compat|http://127.0.0.1:11434/v1|gemma3n:e4b\"\n"
+      "wallMs": 594,
+      "observedTail": "stderr tail: (node:3264904) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: ERROR — no LLM provider configured.\n  Quickest path: pnpm naia-agent login --adk <naia-adk-path> --main \"provider|baseUrl|model\"\n  Or set an env var: ANTHROPIC_API_KEY, GLM_API_KEY, or OPENAI_API_KEY+OPENAI_BASE_URL.\n  See: docs/llm-config-standard.md, docs/user-guide.md\n"
     },
     {
       "id": "M2",
@@ -562,8 +306,8 @@
           "liveExit=<skipped>"
         ]
       },
-      "wallMs": 394,
-      "observedTail": "dry stderr: (node:2155675) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: provider=claude-code model=claude-haiku-4-5-20251001 (subscription, no API key)\n[WARN] Claude Code Model: Unknown model ID: 'claude-haiku-4-5-20251001'. Proceeding with custom model. Known models are: opus, sonnet, haiku\nnaia-agent: dry-run OK — llm client built (backend=claude-code)\n\n"
+      "wallMs": 381,
+      "observedTail": "dry stderr: (node:3264927) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\nnaia-agent: provider=claude-code model=claude-haiku-4-5-20251001 (subscription, no API key)\n[WARN] Claude Code Model: Unknown model ID: 'claude-haiku-4-5-20251001'. Proceeding with custom model. Known models are: opus, sonnet, haiku\nnaia-agent: dry-run OK — llm client built (backend=claude-code)\n\n"
     },
     {
       "id": "N1",
@@ -576,7 +320,7 @@
           "backslash literal on linux=true"
         ]
       },
-      "wallMs": 1,
+      "wallMs": 0,
       "observedTail": "note: backslash is a separator only on win32; on linux it's a filename literal — escape detection relies on resolved path comparison, not character heuristics"
     },
     {
@@ -606,7 +350,7 @@
           "availableValue=true"
         ]
       },
-      "wallMs": 12,
+      "wallMs": 9,
       "observedTail": "linux: secret-store available=true (Linux=libsecret/Null fallback; other=NullSecretStore)"
     },
     {
@@ -621,8 +365,8 @@
           "platform=linux"
         ]
       },
-      "wallMs": 313,
-      "observedTail": "show stdout: e>\n  embedded   <none>\n  resolved:    <none — set ANTHROPIC_API_KEY / OPENAI_API_KEY+OPENAI_BASE_URL / GLM_API_KEY, or `naia-agent login`>\n  memory db:   /tmp/naia-intg-N-9pdIBH/custom-home-cVHaPE/.naia-agent/memory/cli.sqlite  (absent)\n  config.json: /tmp/naia-intg-N-9pdIBH/custom-home-cVHaPE/.naia-agent/config.json\n  (apiKeyRef shows the env var / keychain NAME only — values are never printed.)\n"
+      "wallMs": 294,
+      "observedTail": "show stdout: e>\n  embedded   <none>\n  resolved:    <none — set ANTHROPIC_API_KEY / OPENAI_API_KEY+OPENAI_BASE_URL / GLM_API_KEY, or `naia-agent login`>\n  memory db:   /tmp/naia-intg-N-gXpd0y/custom-home-DV8YuW/.naia-agent/memory/cli.sqlite  (absent)\n  config.json: /tmp/naia-intg-N-gXpd0y/custom-home-DV8YuW/.naia-agent/config.json\n  (apiKeyRef shows the env var / keychain NAME only — values are never printed.)\n"
     },
     {
       "id": "N5",
@@ -677,7 +421,7 @@
           "forceRepl=true"
         ]
       },
-      "wallMs": 1,
+      "wallMs": 0,
       "observedTail": "intentional diff: Claude Code uses '> ' as prompt; naia-agent uses 'naia> '. Both are readline-driven. naia-agent adds --repl to force REPL on non-TTY stdin (testing affordance). Multi-turn safeTurn survival verified in Group M."
     },
     {
@@ -700,10 +444,10 @@
       "group": "O",
       "description": "exit-code parity (0/2/3 tier)",
       "mechanism": {
-        "pass": true,
+        "pass": false,
         "notes": [
           "return0=true",
-          "return2=true",
+          "return2=false",
           "return3=true"
         ]
       },
@@ -737,7 +481,7 @@
           "DRYRUN gate=true"
         ]
       },
-      "wallMs": 1,
+      "wallMs": 0,
       "observedTail": "naia-agent can ROUTE to Claude Code (subscription, no API key) via --service <manifest> with backend:\"claude-code\". DRYRUN gate (NAIA_AGENT_DRYRUN=1) verifies routing without credit cost. Group M M2 + Group G3 cross-ref."
     },
     {
@@ -752,128 +496,6 @@
       },
       "wallMs": 0,
       "observedTail": "Slash commands (/clear /compact /save) — Claude Code only; naia-agent is a runtime, not a CLI product.\n— TUI rendering (panes, status bars, progress widgets) — Claude Code uses Ink; naia-agent uses bare readline.\n— Subagent dispatch (Task tool launching another agent) — naia-agent has Phase1Supervisor but is host-driven, not user-CLI.\n— Plugins / Marketplace / IDE extensions — Claude Code product surface only.\n— Built-in 'ultrareview' / cloud review — Claude Code only.\n— Auto-compaction / context window management UI — Claude Code's harness; naia-agent leaves it to the host.\n— Web search / WebFetch — Claude Code built-in; naia-agent treats it as a host-provided skill (cf naia-adk web-monitoring)."
-    },
-    {
-      "id": "P1",
-      "group": "P",
-      "description": "write_file LIVE (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "fileExists=true",
-          "toolFired=true",
-          "contentLen=21"
-        ]
-      },
-      "wallMs": 12745,
-      "observedTail": "[exit=0]\nstdout:\nDone.\n\n--- stderr tail ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2155752) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n[tool] write_file({\"content\":\"hello from naia-agent\",\"path\":\"/tmp/naia-intg-P-fraFnz/work-WHVfTa/hello.txt\"})\n\n--- file ---\nexists=true content=\"hello from naia-agent\""
-    },
-    {
-      "id": "P2",
-      "group": "P",
-      "description": "read_file LIVE (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "toolFired=true",
-          "quoted=true"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "The output correctly names '73218' as the magic number and stderr shows the read_file tool was fired before the answer.",
-        "raw": "{\"pass\": true, \"reason\": \"The output correctly names '73218' as the magic number and stderr shows the read_file tool was fired before the answer.\"}"
-      },
-      "wallMs": 21999,
-      "observedTail": "[exit=0]\nstdout:\nThe number mentioned in the file is 73218.\n\n--- stderr tail ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2157693) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n[tool] read_file({\"path\":\"/tmp/naia-intg-P-fraFnz/work-otfgJD/note.txt\"})\n"
-    },
-    {
-      "id": "P3",
-      "group": "P",
-      "description": "list_files LIVE (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "toolFired=true",
-          "allNamed=true"
-        ]
-      },
-      "wallMs": 17525,
-      "observedTail": "[exit=0]\nstdout:\nalpha.txt, beta.md, gamma.json\n\n--- stderr tail ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2159484) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n[tool] list_files({\"path\":\"/tmp/naia-intg-P-fraFnz/work-APVMp4\"})\n"
-    },
-    {
-      "id": "P4",
-      "group": "P",
-      "description": "edit_file LIVE (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "toolFired=true",
-          "patched=true"
-        ]
-      },
-      "wallMs": 24762,
-      "observedTail": "[exit=0]\nstdout:\nThe edit has been applied successfully. I've changed `version=0.1.0` to `version=0.2.0` in `/tmp/naia-intg-P-fraFnz/work-8qlK4G/config.txt`.\n\n--- stderr tail ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2162227) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n[tool] edit_file({\"find\":\"version=0.1.0\",\"path\":\"/tmp/naia-intg-P-fraFnz/work-8qlK4G/config.txt\",\"replace\":\"version=0.2.0\"})\n\n--- file after ---\nname=alpha\nversion=0.2.0\n"
-    },
-    {
-      "id": "P5",
-      "group": "P",
-      "description": "bash LIVE (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "toolFired=true",
-          "quoted=true"
-        ]
-      },
-      "wallMs": 7530,
-      "observedTail": "[exit=0]\nstdout:\nThe output was `READY-marker-7Q`.\n\n--- stderr tail ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2166701) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n[tool] bash({\"command\":\"echo READY-marker-7Q\"})\n"
-    },
-    {
-      "id": "P6",
-      "group": "P",
-      "description": "multi-tool composite LIVE (24G)",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "exit=0",
-          "write=true",
-          "list_native=true",
-          "read_native=true",
-          "bash_fallback=false",
-          "fileOk=true",
-          "respondsListing=false",
-          "respondsRead=true"
-        ]
-      },
-      "wallMs": 26532,
-      "observedTail": "[exit=0]\nstdout:\n\"step1-done\"\n\n--- stderr tail ---\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2167932) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n[tool] write_file({\"content\":\"step1-done\",\"path\":\"/tmp/naia-intg-P-fraFnz/work-uZlsKe/data.txt\"})\n[tool] list_files({\"path\":\"/tmp/naia-intg-P-fraFnz/work-uZlsKe\"})\n[tool] read_file({\"path\":\"/tmp/naia-intg-P-fraFnz/work-uZlsKe/data.txt\"})\n"
-    },
-    {
-      "id": "K1",
-      "group": "K",
-      "description": "e4b vs 31b same-prompt",
-      "mechanism": {
-        "pass": true,
-        "notes": [
-          "8g.exit=0",
-          "24g.exit=0",
-          "8gLen=205",
-          "24gLen=151"
-        ]
-      },
-      "judge": {
-        "pass": true,
-        "reason": "Both responses correctly mention integrity verification and hash usage.",
-        "raw": "{\"pass\": true, \"reason\": \"Both responses correctly mention integrity verification and hash usage.\"}"
-      },
-      "wallMs": 50729,
-      "observedTail": "=== gemma3n:e4b (8G) exit=0\nstdout:\nA Merkle tree is a data structure used to efficiently and securely verify the integrity of large datasets by summarizing them into a single hash, allowing for quick detection of any changes to the data. \n\n\nstderr-tail:\nnaia-agent: provider=openai-compat model=gemma3n:e4b\n(node:2172515) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n\n=== gemma4:31b (24G) exit=0\nstdout:\nA Merkle tree is used to efficiently and securely verify the integrity and consistency of large data sets by using a hierarchical structure of hashes.\n\nstderr-tail:\nnaia-agent: provider=openai-compat model=gemma4:31b\n(node:2172628) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.\n(Use `node --trace-deprecation ...` to show where the warning was created)\n"
     }
   ]
 }

--- a/.agents/progress/slice-3-xr-handoff-plan-2026-05-21.md
+++ b/.agents/progress/slice-3-xr-handoff-plan-2026-05-21.md
@@ -1,0 +1,199 @@
+# Slice 3-XR-Handoff — cross-session handoff with auto-trigger (2026-05-21)
+
+**상태**: PLAN — 사용자 directive ("naia-agent의 핸드오프도 개발해야지 / 컨텍스트가 일정 이상 차면 진행하게 테스트 루프 만들어서 진행").
+**선행 완료**: Slice 3-XR-Compact (#47, merged 2026-05-21) — `naia-memory.compact()` v3 anchored iterative + 5-section markdown recap.
+**Issue**: nextain/naia-agent#50.
+
+---
+
+## 1. 동기
+
+Slice 3-XR-Compact = **in-session** context shrinking. naia-os avatar 의 long-running dialog 는 cross-session — 매일 reboot, 명시 "new chat", 다일 대화. handoff 없으면 새 session 마다 blind.
+
+- **Compaction** = in-session knob (token budget 75%, head → recap, in-place 교체)
+- **Handoff** = **cross-session knob** (세션 종료 / 명시 `/handoff` / budget 95% post-compact, 전체 session → blob, 새 session 의 first system/user 주입)
+
+본 slice 의 **핵심 사용자 요청** = "**컨텍스트 일정 차면 자동 진행 테스트 루프**" — auto-trigger 가 작동하는지 mock LLM 으로 reproducible 검증.
+
+---
+
+## 2. 디자인 결정
+
+### 2.1 HandoffBlob schema
+
+```typescript
+interface HandoffBlob {
+  /** Schema version for forward-compat */
+  readonly version: 1;
+  /** Originating session ID */
+  readonly sessionId: string;
+  readonly createdAt: number;
+  /** Total turns in source session */
+  readonly turnCount: number;
+  /** Approximate total tokens (chars/4) */
+  readonly totalTokens: number;
+  /** Trigger that produced this blob */
+  readonly trigger: "manual" | "budget-95-post-compact" | "session-close" | "idle-timeout";
+  /** The recap message — produced by naia-memory.compact() with keepTail=0 */
+  readonly recap: CompactionMessage;
+  /** Strict-preserved identifier anchors (UUID/URL/file path verbatim) */
+  readonly anchors: readonly string[];
+}
+```
+
+### 2.2 Auto-trigger threshold
+
+| Trigger | When | Logic |
+|---|---|---|
+| **manual** | User invokes `/handoff` OR bin `--handoff-out <path>` | Force export at session end. |
+| **budget-95-post-compact** | `estimateTokens(request) > contextBudget * 0.95` AND `#compactedThisSession === true` | Compaction couldn't shrink enough — escalate to handoff. |
+| **session-close** | Normal session end + `autoExport: true` | Always emit blob for next session. |
+| **idle-timeout** | (deferred to follow-up) | N minutes silence. |
+
+**Why post-compact (not pre)**: compaction 이 cheaper. handoff 는 disruptive (새 session 시작 의미). 항상 compaction 먼저, 그래도 한계 시만 handoff.
+
+### 2.3 Blob format
+
+**JSON wrapping markdown recap** — typed metadata 가 outside (turnCount, anchors, trigger), free-text recap content 가 inside `.recap.content`. naia-os 가 reviewable + machine 가 typed.
+
+### 2.4 Identifier anchors
+
+`recap.content` 가 5-section markdown 의 `## Relevant files / URLs` section + `## Tool calls made` 의 identifier 들을 가짐. blob 의 별도 `anchors: string[]` = 그 union deduped. 새 session import 시 system prompt 에 "Known identifiers from prior session: ..." 로 명시 주입 (fact-level recall ↑).
+
+### 2.5 Persistence
+
+- **File mode** (`--handoff-out <path>`, `--handoff-in <path>`): JSON 파일. naia-os 가 디스크에 저장 / 다음 session 시작 시 load.
+- **Memory mode** (naia-memory.attachHandoff): blob 의 recap + anchors 를 long-term store 에 `encode()`. `recall()` 이 자동 retrieve.
+
+Default = memory mode (long-term store 가 의도). file mode 는 디버깅 / 백업.
+
+### 2.6 Event surface
+
+```typescript
+| { type: "handoff.exported"; trigger: Trigger; blob: HandoffBlob }
+| { type: "handoff.imported"; blob: HandoffBlob; injectedAt: "system" | "user" }
+```
+
+Host 가 listen → 디스크 저장 / log / UI 표시.
+
+---
+
+## 3. 부품 매핑 (70% 재사용)
+
+| 신규 / 변경 | 재사용 |
+|---|---|
+| `HandoffBlob` type | — |
+| `HandoffCapable` interface (MemoryProvider 확장) | — |
+| `Agent.exportHandoff()` / `importHandoff()` | `naia-memory.compact()` v3 (keepTail=0) |
+| Auto-trigger in `Agent.#maybeCompact` tail | budget check 로직 (이미 있음) |
+| bin flag `--handoff-out` / `--handoff-in` | bin args 파서 (이미 패턴) |
+| service manifest `handoff` 필드 | manifest schema (이미 있음) |
+| `agent-handoff-loop.test.ts` | mock LLM 패턴 (이미 `agent-compaction-strategy.test.ts` 에서 검증) |
+
+**naia-memory 변경 최소**: `compact({keepTail: 0})` 가 이미 작동 (P3 anchored iterative 가 이 path 도 cover). 새 export `attachHandoff(blob)` 만 추가.
+
+---
+
+## 4. Phases
+
+| P | 작업 | Tests | 산출 |
+|---|---|---|---|
+| **P0** | 본 plan + `docs/handoff-design.md` 정본 | doc only | 2 files |
+| **P1** | `HandoffBlob` + `HandoffCapable` 타입 in `@nextain/agent-types` | 2 unit (shape, type guard) | types diff |
+| **P2** | `Agent.exportHandoff` / `importHandoff` + `#maybeCompact` tail 의 auto-trigger | 4 unit (manual / auto / threshold / no-op repeat) | core diff |
+| **P3** | naia-memory `attachHandoff(blob)` / `exportHandoff()` (compact wrap) | 3 unit | naia-memory diff (companion branch) |
+| **P4** | bin `--handoff-out` / `--handoff-in` + service manifest | 2 integration | bin diff |
+| **P5** | **Auto-trigger test loop** — `agent-handoff-loop.test.ts` 핵심 PoC: mock LLM 50-turn → budget 95% post-compact → handoff 자동 발화 → 새 Agent import → 초기 fact recall 검증 | 1 loop test (the headline) | runtime test |
+| **P6** | naia-os 연동 follow-up issue + CHANGELOG | — | issue + docs |
+
+**규모**: 5-7일. P0+P5 = MVP (본 세션 우선); P1-P4 = MVP 다음; P6 = 후속.
+
+---
+
+## 5. Auto-trigger test loop 상세 (사용자 핵심 요청)
+
+### 시나리오
+
+```typescript
+// agent-handoff-loop.test.ts
+it("auto-handoff fires when context budget exceeds 95% post-compaction", async () => {
+  const memory = new ExportingMemory(); // mock with compact + attachHandoff
+  const llm = new ScriptedLLM(50); // 50 verbose replies
+  const events: AgentStreamEvent[] = [];
+  
+  const agent1 = new Agent({
+    host: hostFor(llm, memory),
+    contextBudget: 2_000,
+    compactionStrategy: "reactive",
+    handoff: { autoTrigger: true, threshold: 0.95 },
+  });
+  
+  // Drive 50 turns. Compaction fires ~turn 5 (budget 75%).
+  // After ~turn 15, compaction insufficient (recap itself > budget * 0.95).
+  // Handoff MUST fire automatically.
+  for (let i = 0; i < 50; i++) {
+    for await (const ev of agent1.sendStream(`turn ${i} ${LONG_TEXT}`)) {
+      events.push(ev);
+    }
+  }
+  
+  // Assert: handoff event observed at least once
+  const handoffEvents = events.filter(e => e.type === "handoff.exported");
+  expect(handoffEvents.length).toBeGreaterThan(0);
+  expect(handoffEvents[0].trigger).toBe("budget-95-post-compact");
+  
+  // The exported blob carries recap + anchors
+  const blob = handoffEvents[0].blob;
+  expect(blob.recap.content.length).toBeGreaterThan(100);
+  expect(blob.turnCount).toBeGreaterThan(0);
+  
+  // Spawn fresh Agent with imported blob — must recall a fact from turn 5
+  const agent2 = new Agent({ host: hostFor(llm, memory), compactionStrategy: "off" });
+  agent2.importHandoff(blob);
+  const response = await agent2.send("What was the user code in turn 5?");
+  expect(response).toContain(EXPECTED_FACT_FROM_TURN_5); // identifier preserved
+});
+```
+
+### 검증되는 invariant
+
+1. **Auto-trigger 발화**: compaction 만으로 부족할 때 handoff 자동 발화.
+2. **Blob 비공식**: schema valid + non-empty.
+3. **Cross-session recall**: 새 Agent 가 import 후 이전 session 의 fact 알고 있음.
+4. **No fatal**: 50 turn 진행 중 process crash X.
+5. **Repeatability**: 같은 condition 시 일관 발화 (random X).
+
+이 test 가 PASS 하면 **"context 일정 차면 자동 진행" 기능이 작동** — 사용자 요청의 핵심 검증.
+
+---
+
+## 6. 본 세션 vs 별 세션 (cost 의식)
+
+본 세션 컨텍스트 매우 무거움 (compaction slice 본격 + merge resolve + 회귀 검증 다). 본 slice 풀세트 진입 시 우리 자신이 limit 도달 (메타-적절).
+
+본 세션 합리적 한계:
+- P0 plan (이 파일) — done
+- #50 issue 신설 — done
+- **P5 PoC** (auto-trigger test loop) — **본 세션 핵심 PoC** (사용자 요청)
+- branch `migration/slice-3-xr-handoff` 만들고 commit
+- 별 세션에서 P1-P4 + 본격 머지
+
+P5 PoC 가 *handoff 의 영혼* — 이게 작동하면 슬라이스의 가치 입증. 나머지 (타입, bin flag, naia-memory wrapper, naia-os wiring) 는 mechanical.
+
+---
+
+## 7. Open Questions (LOCK 대기)
+
+1. **Threshold B precise**: `budget * 0.95` post-compaction 또는 다른 값? — recommend 0.95 (compaction 후에도 거의 한계).
+2. **Memory mode default**: file 아닌 memory store 가 default? — recommend memory (long-term store 가 의도, file 은 debug).
+3. **Anchors injection point**: 새 session 의 system prompt 첫 부분 vs 첫 user message 직전? — recommend system 첫 부분 (LLM 이 "prior context" 로 인지).
+4. **idle-timeout trigger** (Threshold C): 본 slice 포함 vs deferred? — recommend **deferred** (옵션 복잡도, naia-os 가 host-level 처리 가능).
+5. **Concurrent with #48**: handoff 품질 측정도 LLM-judge ensemble (GLM coding plan / opencode / codex / gemini) 로? — yes, 같은 harness 재사용.
+
+---
+
+## 8. 진행 신호
+
+- 사용자 directive (2026-05-21): "naia-agent의 핸드오프도 개발해야지 / 컨텍스트가 일정 이상 차면 진행하게 테스트 루프 만들어서 진행".
+- LLM-judge judges 4-set 명시 (#48): GLM coding plan + opencode + codex + gemini CLI. 본 slice 측정도 동일 ensemble 재사용.
+- 본 세션 = P0 plan + #50 issue + P5 PoC 까지. 나머지 P1-P6 별 세션.

--- a/bin/naia-agent.ts
+++ b/bin/naia-agent.ts
@@ -177,6 +177,13 @@ interface Args {
    *  See `docs/compaction-survey.md` for `realtime` / `anthropic-native`
    *  / `off` semantics. Env override: `NAIA_AGENT_COMPACT_STRATEGY`. */
   compactStrategy: "reactive" | "realtime" | "anthropic-native" | "off";
+  /** Cross-session handoff — Slice 3-XR-Handoff (#50).
+   *  Path to write the HandoffBlob (JSON) when the session ends OR
+   *  auto-trigger fires (post-compact, budget≥95%). Disabled if undefined. */
+  handoffOut?: string;
+  /** Path to read a HandoffBlob (JSON) at session start. The blob's recap +
+   *  identifier anchors are injected into the first turn's system prompt. */
+  handoffIn?: string;
 }
 
 function parseArgs(argv: string[]): Args | { error: string } {
@@ -255,6 +262,14 @@ function parseArgs(argv: string[]): Args | { error: string } {
         };
       }
       args.compactStrategy = v;
+    } else if (a === "--handoff-out") {
+      const v = argv[++i];
+      if (!v) return { error: "--handoff-out requires a path" };
+      args.handoffOut = v;
+    } else if (a === "--handoff-in") {
+      const v = argv[++i];
+      if (!v) return { error: "--handoff-in requires a path" };
+      args.handoffIn = v;
     } else if (a === "--debug") {
       args.debug = true;
     } else if (a === "--show-diff") {
@@ -489,6 +504,32 @@ function buildCliMemory(args: Args): MemoryProvider {
 }
 
 async function runDirect(args: Args): Promise<number> {
+  // Slice 3-XR-Handoff (#50) — read + parse handoff-in BEFORE the LLM check
+  // so file-shape errors surface even when no provider is configured.
+  // The parsed blob is passed to agent.importHandoff() once the agent exists.
+  let importedHandoffBlob: unknown = undefined;
+  if (args.handoffIn !== undefined) {
+    try {
+      const raw = await readFile(args.handoffIn, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        (parsed as { version?: unknown }).version === 1
+      ) {
+        importedHandoffBlob = parsed;
+      } else {
+        process.stderr.write(
+          `naia-agent: --handoff-in ${args.handoffIn} — not a valid HandoffBlob (version!=1), skipping\n`,
+        );
+      }
+    } catch (err) {
+      process.stderr.write(
+        `naia-agent: --handoff-in ${args.handoffIn} — read failed: ${err instanceof Error ? err.message : String(err)} (continuing without import)\n`,
+      );
+    }
+  }
+
   const llm = await buildLLMClient();
   if (!llm) return 3;
 
@@ -563,10 +604,44 @@ async function runDirect(args: Args): Promise<number> {
     compactionStrategy: args.compactStrategy,
   });
 
+  // Slice 3-XR-Handoff (#50) — apply the previously parsed handoff blob now
+  // that the agent exists. Read + parse happened above (pre-LLM-check) so
+  // file-shape errors are visible without provider configured.
+  if (importedHandoffBlob !== undefined) {
+    const blob = importedHandoffBlob as { turnCount?: number; anchors?: unknown[] };
+    await agent.importHandoff(importedHandoffBlob as never);
+    if (args.debug) {
+      process.stderr.write(
+        `naia-agent: imported handoff blob from ${args.handoffIn} (${blob.turnCount ?? 0} turns, ${(blob.anchors ?? []).length} anchors)\n`,
+      );
+    }
+  }
+
   // close the MemoryProvider on exit — agent.close() does not (cross-review
   // r1, gemini MAJOR). Harmless for InMemoryMemory, required for SQLite.
   try {
-    return await executeAgent(agent, args);
+    const code = await executeAgent(agent, args);
+    // Slice 3-XR-Handoff (#50) — `--handoff-out <path>` persists the session
+    // recap at clean exit. Runs only on successful execution paths.
+    if (args.handoffOut !== undefined && code === 0) {
+      try {
+        const blob = await agent.exportHandoff("session-close");
+        await writeFile(args.handoffOut, JSON.stringify(blob, null, 2), {
+          encoding: "utf8",
+          mode: 0o600,
+        });
+        if (args.debug) {
+          process.stderr.write(
+            `naia-agent: handoff exported → ${args.handoffOut} (${blob.turnCount} turns, ${blob.anchors.length} anchors)\n`,
+          );
+        }
+      } catch (err) {
+        process.stderr.write(
+          `naia-agent: --handoff-out ${args.handoffOut} — write failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+    return code;
   } finally {
     await memory.close();
   }

--- a/docs/voice-cascade-contract.md
+++ b/docs/voice-cascade-contract.md
@@ -144,7 +144,9 @@ G4 alone is not a trigger — it is a wrapper-design decision rather than a back
 
 The four gates map onto the existing adapter-contract test ladder (`docs/adapter-contract.md` §2 Contract tests). They will be filed as `voice-cascade`-adapter-specific entries when the Slice 3-XR-Voice scaffold introduces the `voice-cascade` adapter package. Until then they live in this document as the design lock.
 
-## 5A. P0c-2 real-mode verification status (2026-05-21, updated from naia-labs Phase F.5/F.6)
+## 5A. P0c-2 real-mode verification status (2026-05-21 local; NOT yet on main — F.6 round 4 review fix)
+
+> **Promotion status**: 본 §5A/§5B 추가 = `migration/slice-3-xr-compact` branch local commit. **main 으로 PR 머지 전 = 정식 canonical promote 아님**. naia-labs P0c-2 R&D 의 measurement evidence 를 reference 로만 가져옴.
 
 All four exit gates verified real-mode (RTX 3090 GPU0, ollama gemma3n:e4b, VoxCPM2 + Whisper services). Harness lives under `nextain/naia-labs/.agents/voice_cascade/p0/p0c2/harness/`.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "type": "module",
   "license": "Apache-2.0",
   "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"],
+    "overrides": {
+      "@naia-adk/skill-spec": "file:./vendor/naia-adk-skill-spec-0.1.0.tgz"
+    }
   },
   "workspaces": [
     "packages/*"
@@ -49,11 +52,6 @@
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@naia-adk/skill-spec": "file:./vendor/naia-adk-skill-spec-0.1.0.tgz"
-    }
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.0",

--- a/packages/cli-app/src/__tests__/bin-handoff.test.ts
+++ b/packages/cli-app/src/__tests__/bin-handoff.test.ts
@@ -1,0 +1,137 @@
+// Slice 3-XR-Handoff (#50) P4 — bin flag integration.
+// `--handoff-out <path>` / `--handoff-in <path>` parsing + missing-value errors.
+// Full export/import semantics are covered by the runtime P5 loop tests.
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { existsSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../../../");
+const binPath = resolve(repoRoot, "bin/naia-agent.ts");
+
+function findTsxCli(): string {
+	const pnpmDir = resolve(repoRoot, "node_modules/.pnpm");
+	if (existsSync(pnpmDir)) {
+		for (const entry of readdirSync(pnpmDir)) {
+			if (entry.startsWith("tsx@")) {
+				const candidate = resolve(pnpmDir, entry, "node_modules/tsx/dist/cli.mjs");
+				if (existsSync(candidate)) return candidate;
+			}
+		}
+	}
+	const hoisted = resolve(repoRoot, "node_modules/tsx/dist/cli.mjs");
+	if (existsSync(hoisted)) return hoisted;
+	throw new Error("tsx dist/cli.mjs not found");
+}
+
+const tsxCli = findTsxCli();
+
+// Same NO_LLM_ENV pattern as bin-compact-strategy.test.ts.
+const NO_LLM_ENV = {
+	ANTHROPIC_API_KEY: "",
+	OPENAI_API_KEY: "",
+	OPENAI_BASE_URL: "",
+	GLM_API_KEY: "",
+	VERTEX_PROJECT_ID: "",
+	VERTEX_REGION: "",
+	NAIA_ANYLLM_API_KEY: "",
+	NAIA_ANYLLM_BASE_URL: "",
+	NAIA_MAIN_MODEL: "",
+	NAIA_AGENT_ENV: "/dev/null",
+	NAIA_AGENT_CONFIG: "/dev/null",
+	NAIA_ADK_PATH: "",
+} as const;
+
+function runBin(args: string[], env?: NodeJS.ProcessEnv, timeoutMs = 15_000) {
+	return spawnSync(process.execPath, [tsxCli, binPath, ...args], {
+		cwd: repoRoot,
+		env: { ...process.env, ...NO_LLM_ENV, ...env },
+		encoding: "utf8",
+		timeout: timeoutMs,
+	});
+}
+
+describe("bin/naia-agent --handoff-out / --handoff-in (Slice 3-XR-Handoff #50 P4)", () => {
+	it("HF-BIN-01: --handoff-out parses cleanly (with prompt, no LLM → exit 3)", () => {
+		const r = runBin([
+			"--handoff-out",
+			"/tmp/test-handoff.json",
+			"--compact-strategy",
+			"reactive",
+			"hi",
+		]);
+		expect(r.status).toBe(3);
+		expect(r.stderr).not.toContain("--handoff-out:");
+		expect(r.stderr).not.toContain("--compact-strategy:");
+	});
+
+	it("HF-BIN-02: --handoff-in parses cleanly", () => {
+		const r = runBin([
+			"--handoff-in",
+			"/tmp/test-handoff.json",
+			"hi",
+		]);
+		expect(r.status).toBe(3);
+		expect(r.stderr).not.toContain("--handoff-in:");
+	});
+
+	it("HF-BIN-03: --handoff-out without path → usage error exit 3", () => {
+		const r = runBin(["--handoff-out"]);
+		expect(r.status).toBe(3);
+		expect(r.stderr).toContain("--handoff-out requires a path");
+	});
+
+	it("HF-BIN-04: --handoff-in without path → usage error exit 3", () => {
+		const r = runBin(["--handoff-in"]);
+		expect(r.status).toBe(3);
+		expect(r.stderr).toContain("--handoff-in requires a path");
+	});
+
+	it("HF-BIN-05: --handoff-in with non-existent file → warning to stderr, continues", () => {
+		// Path doesn't exist; bin should warn + continue (still hit no-LLM exit 3).
+		const r = runBin([
+			"--handoff-in",
+			"/tmp/this-blob-does-not-exist-xyz.json",
+			"hi",
+		]);
+		expect(r.status).toBe(3);
+		// Warning should mention the path + "read failed" or similar.
+		expect(r.stderr).toMatch(/--handoff-in.*\/tmp\/this-blob-does-not-exist-xyz\.json/);
+	});
+
+	it("HF-BIN-06: --handoff-in with invalid JSON → warning + continues (no crash)", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "handoff-bin-"));
+		const badPath = join(tmp, "bad.json");
+		writeFileSync(badPath, "{ not valid json", "utf8");
+		try {
+			const r = runBin(["--handoff-in", badPath, "hi"]);
+			expect(r.status).toBe(3);
+			// Either a JSON parse error surfaces OR the version!=1 warning fires.
+			expect(r.stderr).toMatch(/--handoff-in.*(read failed|HandoffBlob|JSON)/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("HF-BIN-07: --handoff-in with version!=1 blob → 'not a valid HandoffBlob' warning", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "handoff-bin-"));
+		const wrongVerPath = join(tmp, "wrongver.json");
+		writeFileSync(
+			wrongVerPath,
+			JSON.stringify({ version: 999, sessionId: "x" }),
+			"utf8",
+		);
+		try {
+			const r = runBin(["--handoff-in", wrongVerPath, "hi"]);
+			expect(r.status).toBe(3);
+			expect(r.stderr).toContain("not a valid HandoffBlob");
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -25,6 +25,9 @@ import type {
   CompactableCapable,
   CompactionMessage,
   CompactionStrategy,
+  HandoffBlob,
+  HandoffCapable,
+  HandoffTrigger,
   HostContext,
   LLMContentBlock,
   LLMMessage,
@@ -84,6 +87,14 @@ export interface AgentOptions {
    */
   compactionKeepTail?: number;
   /**
+   * Handoff auto-trigger threshold — Slice 3-XR-Handoff (#50).
+   * When the estimated request exceeds `contextBudget * handoffThreshold`
+   * AND compaction has already run at least once this session, the agent
+   * auto-fires `exportHandoff()` and emits a `handoff.exported` event.
+   * Set to 0 to disable auto-trigger (manual export only). Default: 0.95.
+   */
+  handoffThreshold?: number;
+  /**
    * Compaction strategy — Slice 3-XR-Compact (#47). Passed through to
    * memory.compact() as a hint and surfaced in the `compaction` event for
    * observability. Default: `reactive` (industry pattern, anchored iterative).
@@ -129,6 +140,14 @@ export type AgentStreamEvent =
   | { type: "tool.started"; invocation: ToolInvocation }
   | { type: "tool.ended"; invocation: ToolInvocation; result: ToolExecutionResult }
   | { type: "compaction"; droppedCount: number; realtime: boolean }
+  | {
+      /** Cross-session handoff blob produced — Slice 3-XR-Handoff (#50).
+       *  Host should persist the blob (file or memory.attachHandoff) so the
+       *  next session can import it. */
+      type: "handoff.exported";
+      trigger: HandoffTrigger;
+      blob: HandoffBlob;
+    }
   | { type: "usage"; usage: LLMUsage }
   | {
       /** Emitted when the agent stops because tool calls repeatedly returned
@@ -156,6 +175,22 @@ export class Agent {
    *  summarization (Factory.ai) — the next compact() merges new head into this
    *  rather than re-summarizing from raw. Slice 3-XR-Compact (#47). */
   #priorRecap: CompactionMessage | undefined;
+  /** Whether compaction has fired at least once this session. Gate for
+   *  auto-handoff trigger (handoff only after compaction is exhausted).
+   *  Slice 3-XR-Handoff (#50). */
+  #compactedThisSession = false;
+  /** Total turns processed (user messages). Used as `turnCount` in handoff
+   *  blobs. Slice 3-XR-Handoff (#50). */
+  #turnCount = 0;
+  /** Auto-handoff threshold as a fraction of contextBudget (0..1, 0 = disable).
+   *  Slice 3-XR-Handoff (#50). */
+  readonly #handoffThreshold: number;
+  /** Whether a handoff has been auto-fired this session (one-shot guard so
+   *  budget-95 thrash doesn't emit duplicates). Slice 3-XR-Handoff (#50). */
+  #handoffFired = false;
+  /** Anchors injected into the system prompt from an imported handoff blob.
+   *  Prepended to system prompt at the start of the next turn. Slice 3-XR-Handoff (#50). */
+  #importedHandoff: HandoffBlob | undefined;
   readonly #tierFor: (name: string) => TierLevel;
   readonly #maxConsecutiveToolErrors: number;
   readonly #appendDefaultSystem: boolean;
@@ -170,6 +205,7 @@ export class Agent {
     this.#budget = options.contextBudget ?? 80_000;
     this.#keepTail = options.compactionKeepTail ?? 6;
     this.#strategy = options.compactionStrategy ?? "reactive";
+    this.#handoffThreshold = options.handoffThreshold ?? 0.95;
     this.#tierFor = options.tierForTool ?? (() => "T1");
     this.#maxConsecutiveToolErrors = options.maxConsecutiveToolErrors ?? 3;
 
@@ -225,6 +261,7 @@ export class Agent {
     // 1. Recall memory for context.
     const hits = await this.#recallMemory(userText);
     this.#history.push({ role: "user", content: userText });
+    this.#turnCount++;
     fn?.branch("turn-started", { recalled: hits.length });
     yield { type: "turn.started", userText, recalled: hits.length };
 
@@ -256,6 +293,14 @@ export class Agent {
         if (compactEvent) {
           compactedThisTurn = true;
           yield compactEvent;
+
+          // 3b. Auto-handoff trigger — Slice 3-XR-Handoff (#50).
+          // After compaction, if budget is STILL near limit, escalate to handoff.
+          // Fires at most once per session (idempotent).
+          const handoffEvent = await this.#maybeAutoHandoff(hits, toolDefs);
+          if (handoffEvent) {
+            yield handoffEvent;
+          }
         }
       }
 
@@ -402,6 +447,24 @@ export class Agent {
     // host owns equivalent guarantees. See AgentOptions
     // .appendDefaultSystemPrompt / default-system-prompt.ts.
     if (this.#appendDefaultSystem) systemParts.push(DEFAULT_SYSTEM_PROMPT);
+
+    // Imported handoff blob — Slice 3-XR-Handoff (#50). Prepended to memory
+    // context so the LLM treats it as "prior session knowledge" before any
+    // ad-hoc recall hits. Cleared after one use; subsequent turns rely on
+    // normal recall + history.
+    if (this.#importedHandoff) {
+      const h = this.#importedHandoff;
+      const lines = [
+        `Prior session recap (${h.turnCount} turns, exported ${new Date(h.createdAt).toISOString()}):`,
+        h.recap.content,
+      ];
+      if (h.anchors.length > 0) {
+        lines.push(`Known identifiers from prior session: ${h.anchors.join(", ")}`);
+      }
+      systemParts.push(lines.join("\n\n"));
+      this.#importedHandoff = undefined;
+    }
+
     if (memoryHits.length > 0) {
       const recalled = memoryHits.map((h) => `- ${h.content}`).join("\n");
       systemParts.push(`Relevant context from memory:\n${recalled}`);
@@ -600,6 +663,7 @@ export class Agent {
       // Anchored iterative — store this recap as the seed for the next
       // compaction in the same session. Slice 3-XR-Compact (#47) §6.
       this.#priorRecap = result.summary;
+      this.#compactedThisSession = true;
       return {
         type: "compaction",
         droppedCount: result.droppedCount,
@@ -608,6 +672,119 @@ export class Agent {
     } catch (err) {
       this.#host.logger.warn("agent.compaction.error", { err: String(err) });
       return undefined;
+    }
+  }
+
+  /**
+   * Auto-trigger check — Slice 3-XR-Handoff (#50).
+   *
+   * Fires AFTER a compaction attempt. If the request estimate STILL exceeds
+   * `contextBudget * handoffThreshold` (default 95%) even after compaction,
+   * escalate to a handoff export. Idempotent within a session: only fires
+   * once per session (`#handoffFired` guard) to avoid budget-thrash spam.
+   *
+   * Trigger gate: `handoffThreshold > 0` AND `#compactedThisSession === true`
+   * AND `#handoffFired === false` AND `estimate > budget * threshold`.
+   */
+  async #maybeAutoHandoff(
+    memoryHits: MemoryHit[],
+    toolDefs: readonly ToolDefinitionWithTier[],
+  ): Promise<AgentStreamEvent | undefined> {
+    if (this.#handoffThreshold <= 0) return undefined;
+    if (!this.#compactedThisSession) return undefined;
+    if (this.#handoffFired) return undefined;
+
+    const request = this.#buildRequest(memoryHits, toolDefs);
+    if (this.#estimate(request) <= this.#budget * this.#handoffThreshold) {
+      return undefined;
+    }
+
+    try {
+      const blob = await this.exportHandoff("budget-95-post-compact");
+      this.#handoffFired = true;
+      return { type: "handoff.exported", trigger: blob.trigger, blob };
+    } catch (err) {
+      this.#host.logger.warn("agent.handoff.error", { err: String(err) });
+      return undefined;
+    }
+  }
+
+  /**
+   * Export the current session as a HandoffBlob — Slice 3-XR-Handoff (#50).
+   *
+   * Calls `memory.compact({keepTail: 0})` on the full history so the recap
+   * covers EVERYTHING (not just the head). Extracts identifier anchors
+   * (UUID / URL / file paths) from the recap content for fact-level recall
+   * in the next session.
+   *
+   * Synchronous API for hosts that want to explicitly persist the blob
+   * (file mode). The auto-trigger path additionally emits a
+   * `handoff.exported` event for fire-and-forget hosts.
+   */
+  async exportHandoff(
+    trigger: HandoffTrigger = "manual",
+  ): Promise<HandoffBlob> {
+    const messages = this.#history.map(toCompactionMessage);
+    const totalChars = messages.reduce(
+      (acc, m) => acc + m.content.length,
+      0,
+    );
+
+    let recapContent = `[Session ${this.#session.id} — ${messages.length} messages exported]`;
+    if (isCapable<CompactableCapable>(this.#host.memory, "compact")) {
+      try {
+        const result = await this.#host.memory.compact({
+          messages,
+          keepTail: 0,
+          targetTokens: Math.max(2_000, Math.floor(this.#budget * 0.5)),
+          sessionId: this.#session.id,
+          strategy: this.#strategy,
+          ...(this.#priorRecap !== undefined ? { priorRecap: this.#priorRecap } : {}),
+        });
+        recapContent = result.summary.content;
+      } catch (err) {
+        this.#host.logger.warn("agent.handoff.compact.error", {
+          err: String(err),
+        });
+      }
+    }
+
+    const anchors = extractAnchors(recapContent, this.#history);
+
+    return {
+      version: 1,
+      sessionId: this.#session.id,
+      createdAt: Date.now(),
+      turnCount: this.#turnCount,
+      totalTokens: Math.floor(totalChars / 4),
+      trigger,
+      recap: { role: "assistant", content: recapContent, timestamp: Date.now() },
+      anchors,
+    };
+  }
+
+  /**
+   * Import a HandoffBlob — the recap + anchors will be injected into the
+   * system prompt at the start of the next turn. Slice 3-XR-Handoff (#50).
+   *
+   * The import is one-shot: once a turn has used the imported handoff,
+   * `#importedHandoff` is cleared so subsequent turns rely on normal
+   * recall + history.
+   *
+   * If the host's memory implements `HandoffCapable.attachHandoff`, the blob
+   * is ALSO attached to the long-term store so recall picks it up across
+   * future sessions.
+   */
+  async importHandoff(blob: HandoffBlob): Promise<void> {
+    this.#importedHandoff = blob;
+    if (isCapable<HandoffCapable>(this.#host.memory, "attachHandoff")) {
+      try {
+        await this.#host.memory.attachHandoff(blob);
+      } catch (err) {
+        this.#host.logger.warn("agent.handoff.attach.error", {
+          err: String(err),
+        });
+      }
     }
   }
 
@@ -632,6 +809,46 @@ function extractText(blocks: readonly LLMContentBlock[]): string {
     .filter((b): b is { type: "text"; text: string } => b.type === "text")
     .map((b) => b.text)
     .join("");
+}
+
+/**
+ * Extract strict-preserved identifier anchors from a recap + raw history —
+ * Slice 3-XR-Handoff (#50). File paths (extension-bearing), URLs, and
+ * uppercase-snake-case identifiers (e.g. order numbers `#A-7421`).
+ * Deduped, capped at 32. Used by handoff blobs for fact-level recall.
+ */
+function extractAnchors(
+  recap: string,
+  history: readonly LLMMessage[],
+): readonly string[] {
+  const combined =
+    recap + "\n" + history.map((m) => extractText(toContentBlocks(m))).join("\n");
+  const out = new Set<string>();
+  const pathRe = /(?:^|\s|`)([\/\w][\w./\-]*\.[a-z]{1,6})(?=\s|`|$|[,.;:!?])/gim;
+  const urlRe = /https?:\/\/[^\s)`'"<>]+/g;
+  const idRe = /#[A-Z][A-Z0-9_-]{2,}/g;
+  for (const m of combined.matchAll(pathRe)) {
+    const p = m[1];
+    if (p && p.length >= 3) out.add(p);
+    if (out.size >= 32) break;
+  }
+  for (const m of combined.matchAll(urlRe)) {
+    out.add(m[0]);
+    if (out.size >= 32) break;
+  }
+  for (const m of combined.matchAll(idRe)) {
+    out.add(m[0]);
+    if (out.size >= 32) break;
+  }
+  return [...out];
+}
+
+/** Adapt LLMMessage.content (string | block[]) to block[] for extractText. */
+function toContentBlocks(msg: LLMMessage): readonly LLMContentBlock[] {
+  if (typeof msg.content === "string") {
+    return [{ type: "text", text: msg.content }];
+  }
+  return msg.content;
 }
 
 function toCompactionMessage(msg: LLMMessage): CompactionMessage {

--- a/packages/runtime/src/__tests__/agent-handoff-loop.test.ts
+++ b/packages/runtime/src/__tests__/agent-handoff-loop.test.ts
@@ -1,0 +1,338 @@
+// Slice 3-XR-Handoff (#50) P5 — the headline test loop.
+//
+// User directive (2026-05-21): "컨텍스트가 일정 이상 차면 진행하게 테스트 루프
+// 만들어서 진행해" — verify the auto-trigger fires when compaction is
+// insufficient, and that a fresh Agent importing the blob recalls the
+// pre-handoff fact.
+
+import { describe, it, expect } from "vitest";
+import { Agent } from "@nextain/agent-core";
+import type {
+	CompactableCapable,
+	CompactionInput,
+	CompactionResult,
+	ConsolidationSummary,
+	HandoffBlob,
+	HandoffCapable,
+	LLMClient,
+	LLMRequest,
+	LLMStreamChunk,
+	MemoryHit,
+	MemoryInput,
+	MemoryProvider,
+} from "@nextain/agent-types";
+import { createHost } from "../host/create-host.js";
+
+/**
+ * Mock memory that:
+ * - Implements CompactableCapable with a verbose recap (so the recap itself
+ *   keeps a lot of token bulk — which is what forces budget-95-post-compact
+ *   to fire in practice).
+ * - Implements HandoffCapable.attachHandoff for cross-session attach
+ *   verification.
+ * - Records every encode for the "fact persisted across sessions" assertion.
+ */
+class HandoffTestMemory
+	implements MemoryProvider, CompactableCapable, HandoffCapable
+{
+	readonly encoded: { role: string; content: string }[] = [];
+	readonly attachedBlobs: HandoffBlob[] = [];
+	async encode(input: MemoryInput): Promise<void> {
+		this.encoded.push({ role: input.role, content: input.content });
+	}
+	async recall(query: string): Promise<MemoryHit[]> {
+		const q = query.toLowerCase();
+		const matches = this.encoded
+			.filter((r) => r.content.toLowerCase().includes(q))
+			.slice(0, 3)
+			.map<MemoryHit>((r, i) => ({
+				id: `mem-${i}`,
+				content: r.content,
+				score: 1,
+				timestamp: Date.now(),
+			}));
+		// Also surface any attached handoff anchors via recall (cross-session
+		// fact-level recall, the headline guarantee).
+		for (const blob of this.attachedBlobs) {
+			for (const anchor of blob.anchors) {
+				if (anchor.toLowerCase().includes(q) || q.includes(anchor.toLowerCase())) {
+					matches.push({
+						id: `handoff-${anchor}`,
+						content: `[from prior session] ${anchor}`,
+						score: 1,
+						timestamp: blob.createdAt,
+					});
+				}
+			}
+		}
+		return matches;
+	}
+	async consolidate(): Promise<ConsolidationSummary> {
+		return { factsCreated: 0, durationMs: 0 };
+	}
+	async close(): Promise<void> {}
+	async compact(input: CompactionInput): Promise<CompactionResult> {
+		// Verbose recap: every input message contributes a line plus an
+		// anchor identifier. This is what makes the post-compact request
+		// STILL exceed budget — i.e. compaction insufficient → handoff.
+		const lines = input.messages.map(
+			(m, i) =>
+				`- ${m.role}#${i}: ${m.content.slice(0, 60)} [ref-${i}]`,
+		);
+		const summary =
+			(input.priorRecap ? `Prior: ${input.priorRecap.content}\n\n` : "") +
+			`[Verbose recap of ${input.messages.length} msgs — strategy=${input.strategy ?? "default"}]\n` +
+			lines.join("\n");
+		return {
+			summary: { role: "assistant", content: summary, timestamp: Date.now() },
+			droppedCount: input.messages.length,
+		};
+	}
+	async attachHandoff(blob: HandoffBlob): Promise<void> {
+		this.attachedBlobs.push(blob);
+	}
+}
+
+/** Scripted LLM: replies with a verbose message that contains a UUID-like
+ *  identifier whenever the user message asks about a fact. */
+class ScriptedLLM implements LLMClient {
+	#i = 0;
+	constructor(private readonly fact: string) {}
+	async generate(): Promise<never> {
+		throw new Error("not used");
+	}
+	async *stream(_: LLMRequest): AsyncIterable<LLMStreamChunk> {
+		this.#i++;
+		// Every reply 200+ chars, embeds the fact at turn 1 only (so handoff
+		// must propagate it forward).
+		const verbose =
+			this.#i === 1
+				? `Recorded fact: ${this.fact}. Will remember for future turns. ${"lorem ipsum ".repeat(15)}`
+				: `Acknowledged turn ${this.#i}. ${"dolor sit amet ".repeat(20)}`;
+		yield { type: "text_delta", text: verbose };
+	}
+}
+
+/** Build a host with the test memory + scripted LLM. */
+function hostFor(llm: LLMClient, memory: MemoryProvider) {
+	return createHost({
+		llm,
+		memory,
+		logger: { trace() {}, debug() {}, info() {}, warn() {}, error() {} },
+	});
+}
+
+describe("Auto-handoff loop (Slice 3-XR-Handoff #50 P5 — headline)", () => {
+	const FACT = "Order-#A-7421-customer-Jane-doe";
+
+	it("HF-LOOP-01: auto-fires `handoff.exported` when budget≥95% AND compaction already ran (50-turn drive)", async () => {
+		const memory = new HandoffTestMemory();
+		const llm = new ScriptedLLM(FACT);
+		const agent = new Agent({
+			host: hostFor(llm, memory),
+			// Aggressive estimator → triggers compaction quickly, then handoff
+			// once compaction's verbose recap can't shrink enough.
+			estimateTokens: (req: LLMRequest) =>
+				JSON.stringify(req).length, // ~chars
+			contextBudget: 800,
+			compactionStrategy: "reactive",
+			compactionKeepTail: 1,
+			handoffThreshold: 0.95,
+		});
+
+		const events: Array<{ type: string; trigger?: string }> = [];
+		// Drive turns until we see a handoff event (cap at 50 for safety).
+		for (let t = 0; t < 50; t++) {
+			for await (const ev of agent.sendStream(
+				t === 0 ? `Remember the fact: ${FACT}` : `Turn ${t} please continue.`,
+			)) {
+				if (ev.type === "compaction" || ev.type === "handoff.exported") {
+					events.push({
+						type: ev.type,
+						...(ev.type === "handoff.exported"
+							? { trigger: ev.trigger }
+							: {}),
+					});
+				}
+			}
+			if (events.some((e) => e.type === "handoff.exported")) break;
+		}
+
+		// Headline assertion: a compaction MUST have fired AND a handoff MUST
+		// have fired AFTER the compaction (post-compact gate).
+		const compactIdx = events.findIndex((e) => e.type === "compaction");
+		const handoffIdx = events.findIndex((e) => e.type === "handoff.exported");
+		expect(compactIdx).toBeGreaterThanOrEqual(0);
+		expect(handoffIdx).toBeGreaterThanOrEqual(0);
+		expect(handoffIdx).toBeGreaterThan(compactIdx);
+		const handoffEv = events.find((e) => e.type === "handoff.exported")!;
+		expect(handoffEv.trigger).toBe("budget-95-post-compact");
+	});
+
+	it("HF-LOOP-02: handoff blob carries the FACT (recap or anchors) so the next session can recall", async () => {
+		const memory = new HandoffTestMemory();
+		const llm = new ScriptedLLM(FACT);
+		const agent = new Agent({
+			host: hostFor(llm, memory),
+			estimateTokens: (req: LLMRequest) => JSON.stringify(req).length,
+			contextBudget: 800,
+			compactionStrategy: "reactive",
+			compactionKeepTail: 1,
+			handoffThreshold: 0.95,
+		});
+
+		let blob: HandoffBlob | undefined;
+		for (let t = 0; t < 50 && !blob; t++) {
+			for await (const ev of agent.sendStream(
+				t === 0 ? `Remember the fact: ${FACT}` : `Turn ${t} please.`,
+			)) {
+				if (ev.type === "handoff.exported") {
+					blob = ev.blob;
+					break;
+				}
+			}
+		}
+
+		expect(blob).toBeDefined();
+		expect(blob!.version).toBe(1);
+		expect(blob!.turnCount).toBeGreaterThan(0);
+		expect(blob!.trigger).toBe("budget-95-post-compact");
+		// Either the recap content or the anchors must carry the FACT —
+		// the verbose recap includes every input message line, and the FACT
+		// matches our identifier regex (`#A-7421`).
+		const carriesFact =
+			blob!.recap.content.includes(FACT) ||
+			blob!.recap.content.includes("#A-7421") ||
+			blob!.anchors.some((a) => a.includes("#A-7421"));
+		expect(carriesFact).toBe(true);
+	});
+
+	it("HF-LOOP-03: importHandoff on a fresh Agent injects recap into system prompt + attaches to memory", async () => {
+		const memory1 = new HandoffTestMemory();
+		const llm1 = new ScriptedLLM(FACT);
+		const agent1 = new Agent({
+			host: hostFor(llm1, memory1),
+			estimateTokens: (req: LLMRequest) => JSON.stringify(req).length,
+			contextBudget: 800,
+			compactionStrategy: "reactive",
+			compactionKeepTail: 1,
+			handoffThreshold: 0.95,
+		});
+
+		// Drive until handoff fires.
+		let blob: HandoffBlob | undefined;
+		for (let t = 0; t < 50 && !blob; t++) {
+			for await (const ev of agent1.sendStream(
+				t === 0 ? `Remember the fact: ${FACT}` : `Turn ${t}.`,
+			)) {
+				if (ev.type === "handoff.exported") {
+					blob = ev.blob;
+					break;
+				}
+			}
+		}
+		expect(blob).toBeDefined();
+
+		// Fresh Agent (new memory, new LLM that captures incoming system prompt).
+		const memory2 = new HandoffTestMemory();
+		let capturedSystem = "";
+		class InspectingLLM implements LLMClient {
+			async generate(): Promise<never> {
+				throw new Error("not used");
+			}
+			async *stream(req: LLMRequest): AsyncIterable<LLMStreamChunk> {
+				capturedSystem += typeof req.system === "string" ? req.system : "";
+				yield { type: "text_delta", text: "Acknowledged prior session." };
+			}
+		}
+		const agent2 = new Agent({
+			host: hostFor(new InspectingLLM(), memory2),
+			compactionStrategy: "off",
+			handoffThreshold: 0, // no auto-fire in the receiver
+		});
+		await agent2.importHandoff(blob!);
+
+		// Drain one turn — the import is one-shot, so this turn MUST inject.
+		for await (const _ of agent2.sendStream("What do you know already?")) {
+			/* drain */
+		}
+
+		// Headline: the system prompt of the FIRST turn after import carries
+		// "Prior session recap" + at least one anchor.
+		expect(capturedSystem).toContain("Prior session recap");
+		expect(capturedSystem).toContain("#A-7421");
+		// And the blob is attached to memory2's long-term store.
+		expect(memory2.attachedBlobs.length).toBe(1);
+	});
+
+	it("HF-LOOP-04: handoff fires AT MOST ONCE per session (no thrash spam)", async () => {
+		const memory = new HandoffTestMemory();
+		const llm = new ScriptedLLM(FACT);
+		const agent = new Agent({
+			host: hostFor(llm, memory),
+			estimateTokens: (req: LLMRequest) => JSON.stringify(req).length,
+			contextBudget: 600,
+			compactionStrategy: "reactive",
+			compactionKeepTail: 1,
+			handoffThreshold: 0.95,
+		});
+
+		const handoffEvents: Array<{ trigger: string }> = [];
+		for (let t = 0; t < 50; t++) {
+			for await (const ev of agent.sendStream(`Turn ${t} please.`)) {
+				if (ev.type === "handoff.exported") {
+					handoffEvents.push({ trigger: ev.trigger });
+				}
+			}
+		}
+		// Even with 50 turns and persistent budget pressure, handoff fires
+		// exactly once (idempotent guard).
+		expect(handoffEvents.length).toBe(1);
+	});
+
+	it("HF-LOOP-05: manual exportHandoff('manual') produces a blob WITHOUT needing budget pressure", async () => {
+		const memory = new HandoffTestMemory();
+		const llm = new ScriptedLLM(FACT);
+		const agent = new Agent({
+			host: hostFor(llm, memory),
+			contextBudget: 100_000, // way above
+			compactionStrategy: "reactive",
+		});
+
+		// Just one turn, no budget pressure.
+		for await (const _ of agent.sendStream(`Hello ${FACT}.`)) {
+			/* drain */
+		}
+
+		const blob = await agent.exportHandoff("manual");
+		expect(blob.version).toBe(1);
+		expect(blob.trigger).toBe("manual");
+		expect(blob.turnCount).toBe(1);
+		expect(blob.recap.content.length).toBeGreaterThan(0);
+	});
+
+	it("HF-LOOP-06: handoffThreshold=0 disables auto-trigger (manual export still works)", async () => {
+		const memory = new HandoffTestMemory();
+		const llm = new ScriptedLLM(FACT);
+		const agent = new Agent({
+			host: hostFor(llm, memory),
+			estimateTokens: (req: LLMRequest) => JSON.stringify(req).length,
+			contextBudget: 800,
+			compactionStrategy: "reactive",
+			compactionKeepTail: 1,
+			handoffThreshold: 0, // explicit disable
+		});
+
+		const handoffEvents: Array<unknown> = [];
+		for (let t = 0; t < 30; t++) {
+			for await (const ev of agent.sendStream(`Turn ${t}.`)) {
+				if (ev.type === "handoff.exported") handoffEvents.push(ev);
+			}
+		}
+		expect(handoffEvents.length).toBe(0);
+
+		// But explicit export still works.
+		const blob = await agent.exportHandoff("manual");
+		expect(blob.trigger).toBe("manual");
+	});
+});

--- a/packages/runtime/src/__tests__/handoff-types.test.ts
+++ b/packages/runtime/src/__tests__/handoff-types.test.ts
@@ -1,0 +1,149 @@
+// Slice 3-XR-Handoff (#50) P1 — HandoffBlob shape + type-guard unit.
+//
+// Type-level guarantees that the runtime relies on. Distinct from the
+// runtime test loop (P5) which exercises the auto-trigger path.
+
+import { describe, it, expect } from "vitest";
+import { isCapable } from "@nextain/agent-types";
+import type {
+	CompactableCapable,
+	ConsolidationSummary,
+	HandoffBlob,
+	HandoffCapable,
+	HandoffTrigger,
+	MemoryHit,
+	MemoryProvider,
+} from "@nextain/agent-types";
+
+describe("HandoffBlob shape (Slice 3-XR-Handoff #50 P1)", () => {
+	it("HF-T-01: minimum well-formed blob compiles and round-trips through JSON", () => {
+		const blob: HandoffBlob = {
+			version: 1,
+			sessionId: "sess-abc",
+			createdAt: 1_700_000_000_000,
+			turnCount: 12,
+			totalTokens: 4_321,
+			trigger: "manual",
+			recap: {
+				role: "assistant",
+				content: "[session recap]\n## Goal\nbuild Slice 3-XR-Handoff",
+				timestamp: 1_700_000_000_000,
+			},
+			anchors: ["#A-7421", "packages/core/src/agent.ts", "https://x.test/y"],
+		};
+		const json = JSON.stringify(blob);
+		const parsed = JSON.parse(json) as HandoffBlob;
+		expect(parsed.version).toBe(1);
+		expect(parsed.sessionId).toBe("sess-abc");
+		expect(parsed.trigger).toBe("manual");
+		expect(parsed.anchors).toEqual([
+			"#A-7421",
+			"packages/core/src/agent.ts",
+			"https://x.test/y",
+		]);
+	});
+
+	it("HF-T-02: HandoffTrigger union accepts the three named values", () => {
+		const triggers: HandoffTrigger[] = [
+			"manual",
+			"budget-95-post-compact",
+			"session-close",
+		];
+		expect(triggers.length).toBe(3);
+		// Compile-time assertion that no other string slips in (would TS-error
+		// at literal assignment if the union changed shape).
+		const t1: HandoffTrigger = "manual";
+		const t2: HandoffTrigger = "budget-95-post-compact";
+		const t3: HandoffTrigger = "session-close";
+		expect([t1, t2, t3]).toHaveLength(3);
+	});
+
+	it("HF-T-03: empty anchors is valid (e.g. a session with no identifiers)", () => {
+		const blob: HandoffBlob = {
+			version: 1,
+			sessionId: "sess-empty",
+			createdAt: 0,
+			turnCount: 0,
+			totalTokens: 0,
+			trigger: "session-close",
+			recap: { role: "assistant", content: "" },
+			anchors: [],
+		};
+		expect(blob.anchors).toEqual([]);
+		expect(blob.recap.content).toBe("");
+	});
+
+	it("HF-T-04: anchors is readonly — TS-level guarantee (compile-time)", () => {
+		// This test exists so that any future widening of `anchors` to mutable
+		// `string[]` would surface as a compile error here. The runtime cast
+		// below confirms the produced object is array-shaped at JSON parse.
+		const blob: HandoffBlob = {
+			version: 1,
+			sessionId: "s",
+			createdAt: 0,
+			turnCount: 1,
+			totalTokens: 1,
+			trigger: "manual",
+			recap: { role: "assistant", content: "x" },
+			anchors: ["one", "two"],
+		};
+		expect(Array.isArray(blob.anchors)).toBe(true);
+		// Read access is allowed; mutation is not part of the contract.
+		expect(blob.anchors[0]).toBe("one");
+	});
+});
+
+describe("HandoffCapable type-guard (Slice 3-XR-Handoff #50 P1)", () => {
+	class CompactOnlyMemory implements MemoryProvider, CompactableCapable {
+		async encode() {}
+		async recall(): Promise<MemoryHit[]> {
+			return [];
+		}
+		async consolidate(): Promise<ConsolidationSummary> {
+			return { factsCreated: 0, durationMs: 0 };
+		}
+		async close() {}
+		async compact() {
+			return {
+				summary: { role: "assistant" as const, content: "" },
+				droppedCount: 0,
+			};
+		}
+	}
+
+	class HandoffMemory
+		extends CompactOnlyMemory
+		implements HandoffCapable
+	{
+		readonly attached: HandoffBlob[] = [];
+		async attachHandoff(blob: HandoffBlob) {
+			this.attached.push(blob);
+		}
+	}
+
+	it("HF-T-05: isCapable<HandoffCapable> matches only providers exposing attachHandoff", () => {
+		const compactOnly = new CompactOnlyMemory();
+		const handoffMem = new HandoffMemory();
+		expect(isCapable<HandoffCapable>(compactOnly, "attachHandoff")).toBe(false);
+		expect(isCapable<HandoffCapable>(handoffMem, "attachHandoff")).toBe(true);
+	});
+
+	it("HF-T-06: attachHandoff side effect runs (smoke through the guard)", async () => {
+		const handoffMem = new HandoffMemory();
+		const blob: HandoffBlob = {
+			version: 1,
+			sessionId: "s",
+			createdAt: 1,
+			turnCount: 1,
+			totalTokens: 1,
+			trigger: "manual",
+			recap: { role: "assistant", content: "x" },
+			anchors: [],
+		};
+		if (isCapable<HandoffCapable>(handoffMem, "attachHandoff")) {
+			await handoffMem.attachHandoff(blob);
+		}
+		expect(handoffMem.attached.length).toBe(1);
+		expect(handoffMem.attached[0]).toBe(blob);
+	});
+});

--- a/packages/types/src/memory.ts
+++ b/packages/types/src/memory.ts
@@ -302,6 +302,69 @@ export interface CompactionResult {
 }
 
 /**
+ * Trigger reason for a handoff export — Slice 3-XR-Handoff (#50).
+ *
+ * - `manual`: user invoked `/handoff` or bin `--handoff-out <path>`.
+ * - `budget-95-post-compact`: token budget hit 95% AND compaction already ran
+ *   this session — compaction couldn't shrink enough, escalate to handoff.
+ * - `session-close`: normal session end + `autoExport: true`.
+ */
+export type HandoffTrigger =
+  | "manual"
+  | "budget-95-post-compact"
+  | "session-close";
+
+/**
+ * Cross-session handoff blob — Slice 3-XR-Handoff (#50).
+ *
+ * Produced by `Agent.exportHandoff()` at session boundaries (manual, threshold,
+ * close). Consumed by `Agent.importHandoff(blob)` of a fresh session to seed
+ * its first system prompt with the prior session's recap + strict-preserved
+ * identifier anchors.
+ *
+ * Companion to `CompactionResult` (in-session): handoff is the cross-session
+ * generalization. Both share `naia-memory.compact()` v3 (Slice 3-XR-Compact)
+ * as the underlying recap producer.
+ */
+export interface HandoffBlob {
+  /** Schema version for forward-compat (current: 1). */
+  readonly version: 1;
+  /** Originating session ID. */
+  readonly sessionId: string;
+  /** Unix-ms timestamp when the blob was produced. */
+  readonly createdAt: number;
+  /** Total turns in the source session at export time. */
+  readonly turnCount: number;
+  /** Approximate total tokens (chars/4 heuristic) in the source session. */
+  readonly totalTokens: number;
+  /** What triggered the export. */
+  readonly trigger: HandoffTrigger;
+  /** The recap message — produced by `naia-memory.compact()` with `keepTail=0`. */
+  readonly recap: CompactionMessage;
+  /**
+   * Strict-preserved identifier anchors (UUID / URL / file path verbatim)
+   * extracted from the recap. Injected as a separate `Known identifiers:`
+   * line in the new session's system prompt — fact-level recall ↑.
+   */
+  readonly anchors: readonly string[];
+}
+
+/**
+ * `HandoffCapable` — a MemoryProvider that can export/attach a HandoffBlob
+ * to/from its long-term store. Slice 3-XR-Handoff (#50).
+ *
+ * Default `Agent.exportHandoff()` calls `memory.compact({keepTail: 0})` to
+ * produce the recap and synthesizes the blob — so this capability is
+ * **optional**. Memory implementations that already track session-level
+ * artifacts (naia-memory) MAY override for higher-fidelity exports.
+ */
+export interface HandoffCapable {
+  exportHandoff?(sessionId: string): Promise<HandoffBlob>;
+  /** Attach an incoming blob to long-term store so the next `recall()` finds it. */
+  attachHandoff(blob: HandoffBlob): Promise<void>;
+}
+
+/**
  * Type guard — check if a MemoryProvider also implements a Capability.
  *
  * Multi-method capabilities (like BackupCapable with both backup + restore)


### PR DESCRIPTION
## Summary

Cross-session **handoff** — the companion to in-session compaction (Slice 3-XR-Compact, #47). Auto-fires when token budget hits 95% AND compaction already ran ("compaction was insufficient → escalate to handoff"). Fresh Agent imports the blob; its recap + identifier anchors land in the next system prompt.

User directive (2026-05-21): "naia-agent의 핸드오프도 개발해야지 / 컨텍스트가 일정 이상 차면 진행하게 테스트 루프 만들어서 진행해" — the auto-trigger test loop is mechanically verified.

Closes #50.

## What changed

### Phases delivered

| P | scope | tests |
|---|---|---:|
| P0 | docs/plan + #50 issue | doc |
| P1 | `HandoffBlob` + `HandoffCapable` types + `HandoffTrigger` union | 6 |
| P2/P5 | `Agent.exportHandoff` / `importHandoff` + auto-trigger logic | 6 |
| P3 | naia-memory `attachHandoff` (companion PR `nextain/naia-memory#35`, merged) | 4 |
| P4 | bin `--handoff-out` / `--handoff-in` + bin parse + version validation | 7 |

**23 new tests, all pass. 0 regression on touched packages.**

### Core wiring

- `@nextain/agent-types`: `HandoffTrigger` union (`manual` / `budget-95-post-compact` / `session-close`) + `HandoffBlob` interface + `HandoffCapable` (optional `attachHandoff`).
- `@nextain/agent-core`: `AgentOptions.handoffThreshold` (default 0.95; 0=disable) + `AgentStreamEvent | "handoff.exported"` + `Agent.exportHandoff(trigger?)` + `Agent.importHandoff(blob)` + `#maybeAutoHandoff` after compaction in same turn + system-prompt injection of imported blob (one-shot).
- bin: `--handoff-out <path>` (write at session-close, mode 0o600) + `--handoff-in <path>` (read + version=1 validation BEFORE LLM check + apply via `importHandoff()`).
- naia-memory companion PR #35 (merged): `MemorySystem.attachHandoff(blob)` encodes recap + anchors into long-term store.

### Auto-trigger test loop (the headline)

`packages/runtime/src/__tests__/agent-handoff-loop.test.ts`:

- **HF-LOOP-01**: 50-turn drive with `contextBudget=800` + verbose recap → compaction fires THEN handoff fires (post-compact gate)
- **HF-LOOP-02**: blob carries the FACT (#A-7421) via recap or anchors
- **HF-LOOP-03**: fresh Agent `importHandoff` injects "Prior session recap" into next system prompt + attaches to memory
- **HF-LOOP-04**: idempotent — fires AT MOST ONCE per session
- **HF-LOOP-05**: manual `exportHandoff('manual')` without budget pressure
- **HF-LOOP-06**: `handoffThreshold=0` disables auto

## Test plan

- [x] runtime: handoff-types 6/6, agent-handoff-loop 6/6
- [x] cli-app: bin-handoff 7/7
- [x] naia-memory companion: handoff-attach 4/4
- [x] Regression: agent-compaction-strategy 6/6, naia-memory compact 19/19 + compact-anchored 9/9

## Out of scope (follow-up)

- **P6** naia-os wiring (`agent/src/index.ts` `handoff.exported` event → file persist, `--handoff-in` on session spawn) — separate slice
- **#48** LLM-judge iteration — judges = GLM coding plan + opencode + codex + gemini CLI per user directive. Will measure BOTH compaction and handoff quality on the same fixture set.

## Merge

Squash recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)