### PR TITLE
feat(benchmarks/judges): 4-judge ensemble — GLM coding plan + opencode + codex + gemini (#48 PoC)

### DIFF
--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
-    "bench:compact": "tsx src/runner.ts"
+    "bench:compact": "tsx src/runner.ts",
+    "smoke:judges:live": "tsx scripts/smoke-judges-live.ts"
   },
   "dependencies": {
     "@nextain/agent-types": "workspace:*",

--- a/packages/benchmarks/scripts/smoke-judges-live.ts
+++ b/packages/benchmarks/scripts/smoke-judges-live.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env -S pnpm exec tsx
+/**
+ * LIVE smoke for the 4-judge ensemble — Slice 3-XR-Compact #48.
+ *
+ * Runs ONE sample probe against {GLM, opencode, codex, gemini} concurrently
+ * and prints each judge's verdict, latency, and infra-error reason. Use to
+ * verify the user's local environment actually reaches all four providers
+ * before kicking off a full 10-fixture measurement.
+ *
+ * Usage:
+ *   pnpm --filter @nextain/agent-benchmarks smoke:judges:live
+ *
+ * Prerequisites:
+ *   - GLM_API_KEY in process.env (or ~/.naia-agent/.env loaded by the caller)
+ *   - codex / opencode / gemini CLIs on PATH (brew / native install)
+ *
+ * Exits 0 if at least 2/4 judges return a real verdict (matches ensemble's
+ * "non-unreliable" threshold). Otherwise exits 1 with a per-judge summary.
+ */
+
+import {
+	defaultEnsemble,
+	isInfraError,
+	runEnsemble,
+} from "../src/judges/index.js";
+
+const SAMPLE = {
+	question: "What was the customer's order number and refund eligibility?",
+	response:
+		"Per the conversation, Order #A-7421 from Jane Doe qualifies under the 30-day defective-item policy; refund goes to Visa ending 4291.",
+	criterion:
+		"The response correctly mentions order number #A-7421 AND indicates eligibility/qualification for refund.",
+	timeoutMs: 45_000,
+} as const;
+
+async function main(): Promise<number> {
+	process.stderr.write("[smoke:judges] running 4-judge ensemble on 1 sample probe...\n");
+	const verdict = await runEnsemble({ judges: defaultEnsemble }, SAMPLE);
+
+	process.stdout.write("\n=== Per-judge results ===\n");
+	for (const [name, result] of Object.entries(verdict.perJudge)) {
+		if (isInfraError(result)) {
+			process.stdout.write(
+				`  ${name.padEnd(10)} INFRA  (${result.latencyMs.toFixed(0)}ms) ${result.infraError.slice(0, 200)}\n`,
+			);
+		} else {
+			process.stdout.write(
+				`  ${name.padEnd(10)} ${result.pass ? "PASS " : "FAIL "} (${result.latencyMs.toFixed(0)}ms) ${result.reason}\n`,
+			);
+		}
+	}
+
+	process.stdout.write("\n=== Ensemble verdict ===\n");
+	process.stdout.write(
+		`  pass=${verdict.pass}  valid=${verdict.validCount}/${Object.keys(verdict.perJudge).length}  infra=${verdict.infraErrorCount}  unreliable=${verdict.unreliable}\n`,
+	);
+
+	// Pass criterion: at least 2 judges must return a real verdict (non-infra).
+	if (verdict.validCount < 2) {
+		process.stderr.write(
+			`\n[smoke:judges] FAIL — only ${verdict.validCount}/4 judges returned a real verdict.\n` +
+				`  Check GLM_API_KEY (~/.naia-agent/.env), codex/opencode/gemini CLI installs, and any sandbox/TTY warnings above.\n`,
+		);
+		return 1;
+	}
+	process.stderr.write(
+		`\n[smoke:judges] OK — ${verdict.validCount}/4 judges live. Ensemble is reliable enough to run full benchmarks.\n`,
+	);
+	return 0;
+}
+
+main().then(
+	(code) => process.exit(code),
+	(err: unknown) => {
+		process.stderr.write(`[smoke:judges] FATAL: ${err instanceof Error ? err.message : String(err)}\n`);
+		process.exit(2);
+	},
+);

--- a/packages/benchmarks/src/__tests__/judges.test.ts
+++ b/packages/benchmarks/src/__tests__/judges.test.ts
@@ -1,0 +1,179 @@
+// Slice 3-XR-Compact follow-up (#48) — judge prompt + parse + ensemble unit.
+//
+// LIVE judge invocation (network / CLI subprocess) is gated to opt-in
+// scripts (smoke:judges:live) — runs against real GLM HTTP + codex CLI +
+// opencode CLI + gemini CLI. This file covers the deterministic core.
+
+import { describe, expect, it } from "vitest";
+import {
+	buildJudgePrompt,
+	parseJudgeReply,
+	runEnsemble,
+	isInfraError,
+} from "../judges/index.js";
+import type { Judge, JudgeInput, JudgeResult } from "../judges/index.js";
+
+const SAMPLE: JudgeInput = {
+	question: "What is the order number?",
+	response: "Order #A-7421, customer Jane Doe.",
+	criterion: "Response correctly states order #A-7421",
+};
+
+describe("Judge prompt + parser (Slice 3-XR-Compact #48)", () => {
+	it("JG-PR-01: buildJudgePrompt includes question, response, criterion verbatim", () => {
+		const p = buildJudgePrompt(SAMPLE);
+		expect(p).toContain("What is the order number?");
+		expect(p).toContain("#A-7421");
+		expect(p).toContain("Response correctly states order #A-7421");
+		// Strict-format directive present
+		expect(p).toContain("PASS:");
+		expect(p).toContain("FAIL:");
+	});
+
+	it("JG-PR-02: parseJudgeReply accepts leading 'PASS: ...' line", () => {
+		const v = parseJudgeReply("PASS: response contains the exact order id.", 12);
+		expect(v).not.toBeNull();
+		expect(v!.pass).toBe(true);
+		expect(v!.reason).toContain("exact order id");
+		expect(v!.latencyMs).toBe(12);
+	});
+
+	it("JG-PR-03: parseJudgeReply accepts 'FAIL: ...'", () => {
+		const v = parseJudgeReply("FAIL: response mentions wrong number", 5);
+		expect(v).not.toBeNull();
+		expect(v!.pass).toBe(false);
+	});
+
+	it("JG-PR-04: parser strips surrounding noise and picks first matching line", () => {
+		const text = [
+			"Some preamble noise the judge added.",
+			"PASS: criterion satisfied — id #A-7421 explicit.",
+			"trailing chatter",
+		].join("\n");
+		const v = parseJudgeReply(text, 0);
+		expect(v).not.toBeNull();
+		expect(v!.pass).toBe(true);
+		expect(v!.reason).toContain("criterion satisfied");
+	});
+
+	it("JG-PR-05: parser returns null on missing PASS/FAIL marker", () => {
+		expect(parseJudgeReply("the response was kinda ok", 0)).toBeNull();
+	});
+
+	it("JG-PR-06: parser tolerates case + alternative separators", () => {
+		const v1 = parseJudgeReply("pass - looks good", 0);
+		expect(v1?.pass).toBe(true);
+		const v2 = parseJudgeReply("Fail. wrong", 0);
+		expect(v2?.pass).toBe(false);
+	});
+});
+
+describe("Ensemble majority + infra-error handling (#48)", () => {
+	function fakeJudge(verdict: "PASS" | "FAIL" | "INFRA"): Judge {
+		return async (): Promise<JudgeResult> => {
+			if (verdict === "INFRA") {
+				return { infraError: "simulated", latencyMs: 1 };
+			}
+			return {
+				pass: verdict === "PASS",
+				reason: `simulated ${verdict.toLowerCase()}`,
+				latencyMs: 1,
+			};
+		};
+	}
+
+	it("JG-EN-01: 3 PASS / 1 FAIL → ensemble PASS", async () => {
+		const v = await runEnsemble(
+			{
+				judges: {
+					a: fakeJudge("PASS"),
+					b: fakeJudge("PASS"),
+					c: fakeJudge("PASS"),
+					d: fakeJudge("FAIL"),
+				},
+			},
+			SAMPLE,
+		);
+		expect(v.pass).toBe(true);
+		expect(v.validCount).toBe(4);
+		expect(v.infraErrorCount).toBe(0);
+		expect(v.unreliable).toBe(false);
+	});
+
+	it("JG-EN-02: 1 PASS / 3 FAIL → ensemble FAIL", async () => {
+		const v = await runEnsemble(
+			{
+				judges: {
+					a: fakeJudge("PASS"),
+					b: fakeJudge("FAIL"),
+					c: fakeJudge("FAIL"),
+					d: fakeJudge("FAIL"),
+				},
+			},
+			SAMPLE,
+		);
+		expect(v.pass).toBe(false);
+		expect(v.validCount).toBe(4);
+	});
+
+	it("JG-EN-03: infra errors excluded from majority (2 PASS / 1 FAIL / 1 INFRA → PASS, validCount=3)", async () => {
+		const v = await runEnsemble(
+			{
+				judges: {
+					a: fakeJudge("PASS"),
+					b: fakeJudge("PASS"),
+					c: fakeJudge("FAIL"),
+					d: fakeJudge("INFRA"),
+				},
+			},
+			SAMPLE,
+		);
+		expect(v.pass).toBe(true);
+		expect(v.validCount).toBe(3);
+		expect(v.infraErrorCount).toBe(1);
+		expect(isInfraError(v.perJudge.d!)).toBe(true);
+	});
+
+	it("JG-EN-04: all infra errors → unreliable=true, pass=false", async () => {
+		const v = await runEnsemble(
+			{
+				judges: {
+					a: fakeJudge("INFRA"),
+					b: fakeJudge("INFRA"),
+				},
+			},
+			SAMPLE,
+		);
+		expect(v.unreliable).toBe(true);
+		expect(v.pass).toBe(false);
+		expect(v.validCount).toBe(0);
+		expect(v.infraErrorCount).toBe(2);
+	});
+
+	it("JG-EN-05: tie (1 PASS / 1 FAIL) → ensemble FAIL (no majority for pass)", async () => {
+		const v = await runEnsemble(
+			{
+				judges: { a: fakeJudge("PASS"), b: fakeJudge("FAIL") },
+			},
+			SAMPLE,
+		);
+		expect(v.pass).toBe(false);
+		expect(v.validCount).toBe(2);
+		expect(v.unreliable).toBe(false);
+	});
+
+	it("JG-EN-06: thrown judge surfaces as infra error, not crash", async () => {
+		const throwingJudge: Judge = async () => {
+			throw new Error("simulated boom");
+		};
+		const v = await runEnsemble(
+			{
+				judges: { a: fakeJudge("PASS"), b: throwingJudge },
+			},
+			SAMPLE,
+		);
+		expect(v.validCount).toBe(1);
+		expect(v.infraErrorCount).toBe(1);
+		expect(isInfraError(v.perJudge.b!)).toBe(true);
+	});
+});

--- a/packages/benchmarks/src/judges/cli-judge.ts
+++ b/packages/benchmarks/src/judges/cli-judge.ts
@@ -1,0 +1,129 @@
+/**
+ * CLI-based judges — codex, opencode, gemini — Slice 3-XR-Compact #48.
+ *
+ * Each judge spawns the corresponding CLI as a subprocess with `which`-based
+ * lookup, sends the prompt on argv (no stdin pipe TTY surprises), captures
+ * stdout, and parses with the shared `parseJudgeReply`. Failures route
+ * through `infraError` so the ensemble can majority-vote on valid judges.
+ *
+ * Per `feedback_pi_substrate_not_glm_only_2026_05_20`: real multi-tool
+ * ensemble, not single-judge.
+ */
+
+import { performance } from "node:perf_hooks";
+import { spawn } from "node:child_process";
+import type { Judge, JudgeInput, JudgeResult } from "./types.js";
+import { buildJudgePrompt, parseJudgeReply } from "./prompt.js";
+
+interface CliSpec {
+	readonly name: string;
+	readonly bin: string;
+	/** Args BEFORE the prompt. Prompt is appended as the final argv. */
+	readonly leadingArgs: readonly string[];
+	/** Environment overrides (e.g. trust-mode flags). */
+	readonly env?: Readonly<Record<string, string>>;
+}
+
+const CLI_SPECS: Record<"codex" | "opencode" | "gemini", CliSpec> = {
+	codex: {
+		name: "codex",
+		bin: "codex",
+		leadingArgs: ["exec", "--skip-git-repo-check", "--sandbox", "read-only"],
+	},
+	opencode: {
+		name: "opencode",
+		bin: "opencode",
+		leadingArgs: ["run", "--pure"],
+	},
+	gemini: {
+		name: "gemini",
+		bin: "gemini",
+		leadingArgs: ["--skip-trust", "-p"],
+		env: { GEMINI_CLI_TRUST_WORKSPACE: "true" },
+	},
+};
+
+async function runCli(spec: CliSpec, prompt: string, timeoutMs: number): Promise<{
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+	timedOut: boolean;
+}> {
+	return new Promise((resolve) => {
+		const args = [...spec.leadingArgs, prompt];
+		const proc = spawn(spec.bin, args, {
+			env: { ...process.env, ...(spec.env ?? {}) },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			proc.kill("SIGTERM");
+		}, timeoutMs);
+		proc.stdout.on("data", (chunk) => {
+			stdout += chunk.toString("utf8");
+		});
+		proc.stderr.on("data", (chunk) => {
+			stderr += chunk.toString("utf8");
+		});
+		proc.on("close", (code) => {
+			clearTimeout(timer);
+			resolve({ stdout, stderr, exitCode: code ?? -1, timedOut });
+		});
+		proc.on("error", (err) => {
+			clearTimeout(timer);
+			resolve({
+				stdout,
+				stderr: `${stderr}\n[spawn error] ${err.message}`,
+				exitCode: -1,
+				timedOut: false,
+			});
+		});
+	});
+}
+
+function makeCliJudge(specKey: keyof typeof CLI_SPECS): Judge {
+	const spec = CLI_SPECS[specKey];
+	return async (input: JudgeInput): Promise<JudgeResult> => {
+		const t0 = performance.now();
+		const timeoutMs = input.timeoutMs ?? 60_000;
+		const prompt = buildJudgePrompt(input);
+		try {
+			const result = await runCli(spec, prompt, timeoutMs);
+			const latencyMs = performance.now() - t0;
+			if (result.timedOut) {
+				return {
+					infraError: `${spec.name} timed out after ${timeoutMs}ms`,
+					latencyMs,
+				};
+			}
+			if (result.exitCode !== 0) {
+				return {
+					infraError: `${spec.name} exited ${result.exitCode}: ${result.stderr.slice(-200) || result.stdout.slice(-200)}`,
+					latencyMs,
+				};
+			}
+			// Strip ANSI escapes (some CLIs colorize stdout even non-TTY).
+			const cleaned = result.stdout.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+			const verdict = parseJudgeReply(cleaned, latencyMs);
+			if (!verdict) {
+				return {
+					infraError: `${spec.name} reply unparseable (${cleaned.length} chars): ${cleaned.slice(-200)}`,
+					latencyMs,
+				};
+			}
+			return verdict;
+		} catch (err) {
+			return {
+				infraError: `${spec.name} failed: ${err instanceof Error ? err.message : String(err)}`,
+				latencyMs: performance.now() - t0,
+			};
+		}
+	};
+}
+
+export const codexJudge = makeCliJudge("codex");
+export const opencodeJudge = makeCliJudge("opencode");
+export const geminiJudge = makeCliJudge("gemini");

--- a/packages/benchmarks/src/judges/ensemble.ts
+++ b/packages/benchmarks/src/judges/ensemble.ts
@@ -1,0 +1,73 @@
+/**
+ * Ensemble — majority of valid (non-infra-error) judges. Slice 3-XR-Compact #48.
+ *
+ * Infra errors (CLI missing, key missing, timeout, parse fail) are excluded
+ * from the vote — they're surfaced separately. Tie → unreliable=false, but
+ * caller should look at perJudge to understand. When validCount === 0, the
+ * ensemble verdict is marked `unreliable=true` and `pass=false`.
+ */
+
+import type {
+	EnsembleVerdict,
+	Judge,
+	JudgeInput,
+	JudgeResult,
+} from "./types.js";
+import { isInfraError } from "./types.js";
+
+export interface EnsembleSpec {
+	readonly judges: Readonly<Record<string, Judge>>;
+}
+
+export async function runEnsemble(
+	spec: EnsembleSpec,
+	input: JudgeInput,
+): Promise<EnsembleVerdict> {
+	const names = Object.keys(spec.judges);
+	const results = await Promise.all(
+		names.map(async (name) => {
+			try {
+				const r = await spec.judges[name]!(input);
+				return [name, r] as const;
+			} catch (err) {
+				return [
+					name,
+					{
+						infraError: `unhandled: ${err instanceof Error ? err.message : String(err)}`,
+						latencyMs: 0,
+					} as JudgeResult,
+				] as const;
+			}
+		}),
+	);
+
+	const perJudge: Record<string, JudgeResult> = {};
+	let pass = 0;
+	let fail = 0;
+	let infra = 0;
+	const reasons: string[] = [];
+	for (const [name, r] of results) {
+		perJudge[name] = r;
+		if (isInfraError(r)) {
+			infra++;
+		} else {
+			if (r.pass) pass++;
+			else fail++;
+			reasons.push(`${name}: ${r.pass ? "PASS" : "FAIL"} ${r.reason}`);
+		}
+	}
+	const validCount = pass + fail;
+	const unreliable = validCount === 0;
+	const majority = pass > fail;
+
+	return {
+		pass: !unreliable && majority,
+		reason: reasons.length > 0
+			? reasons.join(" | ")
+			: `unreliable: all ${infra} judges hit infra errors`,
+		perJudge,
+		validCount,
+		infraErrorCount: infra,
+		unreliable,
+	};
+}

--- a/packages/benchmarks/src/judges/glm-judge.ts
+++ b/packages/benchmarks/src/judges/glm-judge.ts
@@ -1,0 +1,82 @@
+/**
+ * GLM coding plan judge — Slice 3-XR-Compact follow-up (#48).
+ *
+ * Uses GLM_API_KEY from process.env (loaded from ~/.naia-agent/.env via the
+ * bin's loadEnvAndConfig in production; the runner exports the var before
+ * calling). Direct HTTPS call to zhipu's OpenAI-compatible endpoint — no
+ * CLI subprocess, so no TTY / sandbox surprises.
+ */
+
+import { performance } from "node:perf_hooks";
+import type { Judge, JudgeInput, JudgeResult } from "./types.js";
+import { buildJudgePrompt, parseJudgeReply } from "./prompt.js";
+
+const GLM_DEFAULT_MODEL = "glm-4.5-flash";
+const GLM_DEFAULT_ENDPOINT = "https://open.bigmodel.cn/api/paas/v4/chat/completions";
+
+export const glmJudge: Judge = async (
+	input: JudgeInput,
+): Promise<JudgeResult> => {
+	const t0 = performance.now();
+	const apiKey = process.env.GLM_API_KEY;
+	if (!apiKey) {
+		return {
+			infraError: "GLM_API_KEY not set in process.env",
+			latencyMs: performance.now() - t0,
+		};
+	}
+	const model = process.env.GLM_MODEL ?? GLM_DEFAULT_MODEL;
+	const endpoint = process.env.GLM_ENDPOINT ?? GLM_DEFAULT_ENDPOINT;
+	const timeoutMs = input.timeoutMs ?? 30_000;
+	const prompt = buildJudgePrompt(input);
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		const res = await fetch(endpoint, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify({
+				model,
+				messages: [{ role: "user", content: prompt }],
+				temperature: 0,
+				max_tokens: 200,
+			}),
+			signal: controller.signal,
+		});
+		clearTimeout(timer);
+		if (!res.ok) {
+			return {
+				infraError: `GLM HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`,
+				latencyMs: performance.now() - t0,
+			};
+		}
+		const body = (await res.json()) as {
+			choices?: { message?: { content?: string } }[];
+			usage?: { total_tokens?: number };
+		};
+		const content = body.choices?.[0]?.message?.content ?? "";
+		const verdict = parseJudgeReply(
+			content,
+			performance.now() - t0,
+			body.usage?.total_tokens,
+		);
+		if (!verdict) {
+			return {
+				infraError: `GLM reply unparseable: ${content.slice(0, 200)}`,
+				latencyMs: performance.now() - t0,
+			};
+		}
+		return verdict;
+	} catch (err) {
+		clearTimeout(timer);
+		return {
+			infraError: `GLM fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+			latencyMs: performance.now() - t0,
+		};
+	}
+};

--- a/packages/benchmarks/src/judges/index.ts
+++ b/packages/benchmarks/src/judges/index.ts
@@ -1,0 +1,38 @@
+/**
+ * LLM-judge ensemble — Slice 3-XR-Compact follow-up (#48).
+ *
+ * Public exports for the judges harness. The runner picks `defaultEnsemble`
+ * which mirrors the user-directed 4-judge panel (GLM coding plan + opencode
+ * + codex + gemini). Tests / smoke scripts can import individual judges to
+ * exercise one provider at a time without the others' env requirements.
+ */
+
+export type {
+	EnsembleVerdict,
+	Judge,
+	JudgeInfraError,
+	JudgeInput,
+	JudgeResult,
+	JudgeVerdict,
+} from "./types.js";
+export { isInfraError } from "./types.js";
+export { buildJudgePrompt, parseJudgeReply } from "./prompt.js";
+export { glmJudge } from "./glm-judge.js";
+export { codexJudge, geminiJudge, opencodeJudge } from "./cli-judge.js";
+export type { EnsembleSpec } from "./ensemble.js";
+export { runEnsemble } from "./ensemble.js";
+
+import type { Judge } from "./types.js";
+import { glmJudge } from "./glm-judge.js";
+import { codexJudge, geminiJudge, opencodeJudge } from "./cli-judge.js";
+
+/**
+ * User-directed 4-judge panel (#48): GLM coding plan (HTTP) + opencode +
+ * codex + gemini CLIs. Use with `runEnsemble({ judges: defaultEnsemble }, ...)`.
+ */
+export const defaultEnsemble: Readonly<Record<string, Judge>> = {
+	glm: glmJudge,
+	opencode: opencodeJudge,
+	codex: codexJudge,
+	gemini: geminiJudge,
+};

--- a/packages/benchmarks/src/judges/prompt.ts
+++ b/packages/benchmarks/src/judges/prompt.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared judge prompt — Slice 3-XR-Compact follow-up (#48).
+ *
+ * The same prompt template is sent to every judge so verdicts are
+ * comparable. Returns a strict 1-line answer: "PASS: ..." or "FAIL: ...".
+ * Reason text is short — judges that hallucinate longer prose force the
+ * parser to strip surrounding noise.
+ */
+
+import type { JudgeInput, JudgeVerdict } from "./types.js";
+
+export function buildJudgePrompt(input: JudgeInput): string {
+	return [
+		"You are an objective evaluator of LLM responses. Read the question,",
+		"the response, and the pass criterion. Decide whether the response",
+		"satisfies the criterion. Reply with EXACTLY ONE LINE in the format:",
+		"  PASS: <one-sentence reason>",
+		"OR",
+		"  FAIL: <one-sentence reason>",
+		"No prose before or after. No quotes.",
+		"",
+		`QUESTION: ${input.question}`,
+		"",
+		`RESPONSE: ${input.response}`,
+		"",
+		`PASS CRITERION: ${input.criterion}`,
+	].join("\n");
+}
+
+/**
+ * Parse a judge's free-text reply into a JudgeVerdict. Strict: leading line
+ * must start with "PASS:" or "FAIL:" (case-insensitive after trim). If the
+ * judge emits prose around it, the first matching line wins. Returns null
+ * when no match — caller treats null as malformed.
+ */
+export function parseJudgeReply(
+	text: string,
+	latencyMs: number,
+	approxTokens?: number,
+): JudgeVerdict | null {
+	const lines = text
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l.length > 0);
+	for (const line of lines) {
+		const m = /^(PASS|FAIL)\s*[:.\-]\s*(.+)$/i.exec(line);
+		if (m) {
+			const verdict = m[1]!.toUpperCase() === "PASS";
+			const verdictBase: JudgeVerdict = {
+				pass: verdict,
+				reason: m[2]!.trim().slice(0, 300),
+				latencyMs,
+			};
+			return approxTokens !== undefined
+				? { ...verdictBase, approxTokens }
+				: verdictBase;
+		}
+	}
+	return null;
+}

--- a/packages/benchmarks/src/judges/types.ts
+++ b/packages/benchmarks/src/judges/types.ts
@@ -1,0 +1,61 @@
+/**
+ * LLM-judge types — Slice 3-XR-Compact follow-up (#48).
+ *
+ * Objective measurement of compaction/handoff quality requires a panel of
+ * independent judges. User-directed ensemble: GLM coding plan (HTTP),
+ * opencode CLI, codex CLI, gemini CLI. Each judge returns the same shape
+ * so the runner can majority-vote without per-judge branching.
+ */
+
+export interface JudgeVerdict {
+	/** Did the response satisfy the criterion? */
+	readonly pass: boolean;
+	/** Free-text reason — surfaced in reports for the failure cases. */
+	readonly reason: string;
+	/** Latency for this judge call in milliseconds. */
+	readonly latencyMs: number;
+	/** Approximate tokens consumed (for cost tracking). */
+	readonly approxTokens?: number;
+}
+
+export interface JudgeInfraError {
+	/** Identifies that the judge could not run (CLI missing, key missing,
+	 *  network down, etc.). Excluded from majority vote. */
+	readonly infraError: string;
+	readonly latencyMs: number;
+}
+
+export type JudgeResult = JudgeVerdict | JudgeInfraError;
+
+export function isInfraError(r: JudgeResult): r is JudgeInfraError {
+	return "infraError" in r;
+}
+
+export interface JudgeInput {
+	/** What was asked of the assistant — the user's probe. */
+	readonly question: string;
+	/** The assistant's actual response we're judging. */
+	readonly response: string;
+	/** What "pass" means for this probe (free-form description). */
+	readonly criterion: string;
+	/** Optional context — fixture id, probe id, anything useful for the
+	 *  judge's reasoning. NOT sent verbatim if it would leak fixture state. */
+	readonly meta?: Record<string, string>;
+	/** Per-call timeout cap in milliseconds (default 30s). */
+	readonly timeoutMs?: number;
+}
+
+/** Judge function signature — every concrete judge implements this. */
+export type Judge = (input: JudgeInput) => Promise<JudgeResult>;
+
+/** Ensemble result — majority of valid (non-infra-error) verdicts. */
+export interface EnsembleVerdict {
+	readonly pass: boolean;
+	readonly reason: string;
+	readonly perJudge: Readonly<Record<string, JudgeResult>>;
+	/** Out of `Object.keys(perJudge).length`, how many returned a real verdict. */
+	readonly validCount: number;
+	readonly infraErrorCount: number;
+	/** validCount === 0 → ensemble verdict is unreliable; runner should flag. */
+	readonly unreliable: boolean;
+}


### PR DESCRIPTION
## Summary

Objective measurement harness — 4 independent LLM judges, majority-vote ensemble, infra-error isolation. Per user directive (2026-05-21):

> "성능 평가도 요청했었지" + "신뢰할만한 성능인지 객관적인 지표도 필요하고"
> "llm judge 는 glm coding plan이나 opencode, codex, gemini cli로 진행해"

This PR ships the plumbing + LIVE smoke probe. The full 10-fixture × 4-strategy × 4-judge run is the follow-up (~600 LLM calls; separate session).

## What changed

`packages/benchmarks/src/judges/`:

| File | Purpose |
|---|---|
| `types.ts` | JudgeVerdict / JudgeInfraError / JudgeResult / JudgeInput / EnsembleVerdict |
| `prompt.ts` | Shared one-line PASS:/FAIL: prompt + tolerant parser |
| `glm-judge.ts` | GLM coding plan via OpenAI-compatible HTTP (`GLM_API_KEY`) |
| `cli-judge.ts` | spawn() wrappers for codex / opencode / gemini (60s timeout, ANSI strip) |
| `ensemble.ts` | `runEnsemble()` majority vote, validCount===0 → unreliable |
| `index.ts` | Public exports + `defaultEnsemble` (the 4-judge panel) |

## Tests

`src/__tests__/judges.test.ts` — **12/12 pass**:
- JG-PR-01..06: prompt + parser invariants
- JG-EN-01..06: ensemble majority logic (3/1, 1/3, infra exclusion, all-infra unreliable, tie → fail, thrown judge → infra surface)

All deterministic (fake judges). LIVE smoke is gated behind opt-in script.

## LIVE smoke

\`\`\`bash
# Pre-flight:
# - source ~/.naia-agent/.env (or export GLM_API_KEY)
# - confirm codex / opencode / gemini CLIs on PATH

pnpm --filter @nextain/agent-benchmarks smoke:judges:live
\`\`\`

Prints per-judge PASS/FAIL/INFRA + latency. Exits 0 iff ≥2 judges return real verdicts (ensemble reliable threshold). Run this BEFORE the full benchmarks measurement to verify the local environment.

## Why this matters

Slice 3-XR-Compact P6 deterministic measurement scored `off`/`anthropic-native` falsely high on fact-recall (documented in `compact-bench-2026-05-20.md` §"Critical interpretation") — keyword matching on the raw transcript instead of evaluating the assistant's actual response. With ensemble judges wired in, the runner can ask 4 independent LLMs "did the assistant's response actually carry the fact?" and majority-vote. **That is the objective metric.**

## Out of scope (next iteration, separate session)

- Wire `runEnsemble()` into `runner.ts` (replace deterministic task-accuracy scoring on `task-accuracy` probes)
- Hard-truncation simulation for `off` strategy
- 10-fixture × 4-strategy × 4-judge measurement
- Embedding-based drift (cosine vs Jaccard)
- Companion measurement for Slice 3-XR-Handoff (cross-session recall fidelity)

## Refs

- nextain/naia-agent#48 (umbrella)
- nextain/naia-agent#47 (Compact — merged, deterministic ledger this harness sharpens)
- nextain/naia-agent#50 (Handoff — merged, also benefits from this ensemble)

## Merge

Squash recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)